### PR TITLE
Fix NativeCallbacks struct alignment: add missing PrecacheAllHeroes field

### DIFF
--- a/managed/DeadworksManaged.Api/NativeCallbacks.cs
+++ b/managed/DeadworksManaged.Api/NativeCallbacks.cs
@@ -81,6 +81,7 @@ internal struct NativeCallbacks
 	public nint DestroyDamageInfo;
 	public nint TakeDamage;
 	public nint PrecacheHero;
+	public nint PrecacheAllHeroes;
 	public nint RegisterConCommand;
 	public nint UnregisterConCommand;
 	public nint CreateConVar;


### PR DESCRIPTION
## Summary
- The managed `NativeCallbacks` struct was missing the `PrecacheAllHeroes` field between `PrecacheHero` and `RegisterConCommand`
- This caused all subsequent fields to be offset by one pointer, so ConCommand registration (and everything after it in the struct) silently called the wrong native function
- All `dw_*` commands and plugin commands failed with "Unknown command" as a result

## Fix
Added the missing `public nint PrecacheAllHeroes;` field to align the managed struct with the native `NativeCallbacks` struct in `NativeCallbacks.hpp`.