### PR TITLE
Add engine log forwarding to managed plugins

### DIFF
--- a/deadworks/src/Core/NativeCallbacks.cpp
+++ b/deadworks/src/Core/NativeCallbacks.cpp
@@ -330,6 +330,31 @@ static void __cdecl NativeExecuteServerCommand(const char *command) {
     g_pEngineServer->ServerCommand(command);
 }
 
+// --- Engine log forwarding to managed code ---
+static void(__cdecl *g_ManagedLogCallback)(const char *message) = nullptr;
+
+class ManagedLoggingListener : public ILoggingListener {
+public:
+    void Log(const LoggingContext_t *pContext, const tchar *pMessage) override {
+        if (g_ManagedLogCallback && pMessage)
+            g_ManagedLogCallback(pMessage);
+    }
+};
+
+static ManagedLoggingListener g_ManagedLoggingListener;
+static bool g_ManagedListenerRegistered = false;
+
+static void __cdecl NativeSetEngineLogCallback(void(__cdecl *callback)(const char *message)) {
+    g_ManagedLogCallback = callback;
+    if (callback && !g_ManagedListenerRegistered) {
+        LoggingSystem_RegisterLoggingListener(&g_ManagedLoggingListener);
+        g_ManagedListenerRegistered = true;
+    } else if (!callback && g_ManagedListenerRegistered) {
+        LoggingSystem_UnregisterLoggingListener(&g_ManagedLoggingListener);
+        g_ManagedListenerRegistered = false;
+    }
+}
+
 static void __cdecl NativeSetModel(void *entity, const char *modelName) {
     if (!entity || !modelName)
         return;
@@ -828,4 +853,7 @@ void deadworks::PopulateNativeCallbacks(NativeCallbacks &callbacks) {
 
     // Global vars
     callbacks.GetGlobalVars = &NativeGetGlobalVars;
+
+    // Engine log forwarding
+    callbacks.SetEngineLogCallback = &NativeSetEngineLogCallback;
 }

--- a/deadworks/src/Core/NativeCallbacks.hpp
+++ b/deadworks/src/Core/NativeCallbacks.hpp
@@ -108,6 +108,7 @@ struct NativeCallbacks {
     int32_t(__cdecl *GetMaxHealth)(void *entity);
     int32_t(__cdecl *Heal)(void *entity, float amount);
     void *(__cdecl *GetGlobalVars)();
+    void(__cdecl *SetEngineLogCallback)(void(__cdecl *callback)(const char *message));
 };
 
 void PopulateNativeCallbacks(NativeCallbacks &callbacks);

--- a/managed/DeadworksManaged.Api/NativeCallbacks.cs
+++ b/managed/DeadworksManaged.Api/NativeCallbacks.cs
@@ -98,4 +98,5 @@ internal struct NativeCallbacks
 	public nint GetMaxHealth;
 	public nint Heal;
 	public nint GetGlobalVars;
+	public nint SetEngineLogCallback;
 }

--- a/managed/DeadworksManaged.Api/NativeInterop.cs
+++ b/managed/DeadworksManaged.Api/NativeInterop.cs
@@ -98,4 +98,5 @@ internal static unsafe class NativeInterop
 	public static delegate* unmanaged[Cdecl]<void*, int> GetMaxHealth => (delegate* unmanaged[Cdecl]<void*, int>)_cb.GetMaxHealth;
 	public static delegate* unmanaged[Cdecl]<void*, float, int> Heal => (delegate* unmanaged[Cdecl]<void*, float, int>)_cb.Heal;
 	public static delegate* unmanaged[Cdecl]<void*> GetGlobalVars => (delegate* unmanaged[Cdecl]<void*>)_cb.GetGlobalVars;
+	public static delegate* unmanaged[Cdecl]<nint, void> SetEngineLogCallback => (delegate* unmanaged[Cdecl]<nint, void>)_cb.SetEngineLogCallback;
 }

--- a/managed/DeadworksManaged.Api/Server.cs
+++ b/managed/DeadworksManaged.Api/Server.cs
@@ -80,24 +80,48 @@ public static unsafe class Server {
 	/// <summary>Delegate type for engine log callbacks.</summary>
 	public delegate void EngineLogHandler(string message);
 
-	private static EngineLogHandler? _engineLogHandler;
+	private static readonly List<EngineLogHandler> _engineLogListeners = new();
+	private static readonly object _engineLogLock = new();
 
 	[UnmanagedCallersOnly(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
 	private static void EngineLogTrampoline(byte* message) {
-		if (_engineLogHandler != null && message != null) {
-			string msg = Marshal.PtrToStringUTF8((nint)message) ?? "";
-			if (!string.IsNullOrEmpty(msg))
-				_engineLogHandler(msg);
+		if (message == null) return;
+		string msg = Marshal.PtrToStringUTF8((nint)message) ?? "";
+		if (string.IsNullOrEmpty(msg)) return;
+
+		EngineLogHandler[] snapshot;
+		lock (_engineLogLock) {
+			if (_engineLogListeners.Count == 0) return;
+			snapshot = _engineLogListeners.ToArray();
+		}
+		foreach (var handler in snapshot)
+			handler(msg);
+	}
+
+	/// <summary>Adds a listener to receive all engine logging output. Multiple listeners are supported.</summary>
+	public static void AddEngineLogListener(EngineLogHandler handler) {
+		ArgumentNullException.ThrowIfNull(handler);
+		bool wasEmpty;
+		lock (_engineLogLock) {
+			wasEmpty = _engineLogListeners.Count == 0;
+			_engineLogListeners.Add(handler);
+		}
+		if (wasEmpty) {
+			nint fnPtr = (nint)(delegate* unmanaged[Cdecl]<byte*, void>)&EngineLogTrampoline;
+			NativeInterop.SetEngineLogCallback(fnPtr);
 		}
 	}
 
-	/// <summary>Registers a callback to receive all engine logging output. Pass null to unregister.</summary>
-	public static void SetEngineLogCallback(EngineLogHandler? handler) {
-		_engineLogHandler = handler;
-		nint fnPtr = handler != null
-			? (nint)(delegate* unmanaged[Cdecl]<byte*, void>)&EngineLogTrampoline
-			: 0;
-		NativeInterop.SetEngineLogCallback(fnPtr);
+	/// <summary>Removes a previously added engine log listener. The native listener is unregistered when the last listener is removed.</summary>
+	public static void RemoveEngineLogListener(EngineLogHandler handler) {
+		ArgumentNullException.ThrowIfNull(handler);
+		bool isEmpty;
+		lock (_engineLogLock) {
+			_engineLogListeners.Remove(handler);
+			isEmpty = _engineLogListeners.Count == 0;
+		}
+		if (isEmpty)
+			NativeInterop.SetEngineLogCallback(0);
 	}
 
 	private static string Utf8Str(byte* ptr) =>

--- a/managed/DeadworksManaged.Api/Server.cs
+++ b/managed/DeadworksManaged.Api/Server.cs
@@ -77,6 +77,29 @@ public static unsafe class Server {
 		return list;
 	}
 
+	/// <summary>Delegate type for engine log callbacks.</summary>
+	public delegate void EngineLogHandler(string message);
+
+	private static EngineLogHandler? _engineLogHandler;
+
+	[UnmanagedCallersOnly(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+	private static void EngineLogTrampoline(byte* message) {
+		if (_engineLogHandler != null && message != null) {
+			string msg = Marshal.PtrToStringUTF8((nint)message) ?? "";
+			if (!string.IsNullOrEmpty(msg))
+				_engineLogHandler(msg);
+		}
+	}
+
+	/// <summary>Registers a callback to receive all engine logging output. Pass null to unregister.</summary>
+	public static void SetEngineLogCallback(EngineLogHandler? handler) {
+		_engineLogHandler = handler;
+		nint fnPtr = handler != null
+			? (nint)(delegate* unmanaged[Cdecl]<byte*, void>)&EngineLogTrampoline
+			: 0;
+		NativeInterop.SetEngineLogCallback(fnPtr);
+	}
+
 	private static string Utf8Str(byte* ptr) =>
 		ptr != null ? Marshal.PtrToStringUTF8((nint)ptr) ?? "" : "";
 }


### PR DESCRIPTION
## Summary
- Adds `SetEngineLogCallback` to `NativeCallbacks`, allowing managed code to receive all engine log output
- Native side hooks `ILoggingListener` and forwards messages through a cdecl callback to managed code
- Exposes `Server.SetEngineLogCallback(handler)` as the public API — pass `null` to unregister

## Test plan
- [ ] Call `Server.SetEngineLogCallback(msg => Console.WriteLine(msg))` in a plugin's `OnLoad`
- [ ] Verify engine log messages are forwarded to the managed handler
- [ ] Pass `null` to unregister and confirm messages stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)