### PR TITLE
Fix broken signatures for latest game update

### DIFF
--- a/config/deadworks_mem.jsonc
+++ b/config/deadworks_mem.jsonc
@@ -74,7 +74,7 @@
 		},
 		"CCitadelGameRules::BuildGameSessionManifest": {
 			"library": "server.dll",
-			"windows": "48 89 54 24 ?? 48 89 4C 24 ?? 55 53 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? ?? ?? ?? 48 8D 0D"
+			"windows": "48 89 54 24 ?? 48 89 4C 24 ?? 55 53 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 4C 8B 02 4C 8B FA 4C 8B E1"
 		},
 		"AddResource": {
 			"library": "server.dll",
@@ -127,7 +127,7 @@
 		},
 		"CCitadelPlayerPawn::AbilityThink": {
 			"library": "server.dll",
-			"windows": "48 89 4C 24 08 55 53 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 8B 91 DC 03"
+			"windows": "48 89 4C 24 08 55 53 56 41 55 41 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 8B 91 DC 03"
 		},
 		"CCitadelPlayerPawn::AddItem": {
 			"library": "server.dll",

--- a/deadworks/src/Core/NativeOffsets.hpp
+++ b/deadworks/src/Core/NativeOffsets.hpp
@@ -31,9 +31,9 @@ constexpr uintptr_t kOnAbilityRemoved_RemoveSlotCall = 0x8D;
 constexpr uintptr_t kSelectHero_GetManagerCall = 0x15;
 
 // CCitadelGameRules::BuildGameSessionManifest
-constexpr uintptr_t kBGSM_GetHeroTableCall = 0x306;
-constexpr uintptr_t kBGSM_PrecacheGlobalLea = 0x33B;
-constexpr uintptr_t kBGSM_PrecacheCall = 0x342;
+constexpr uintptr_t kBGSM_GetHeroTableCall = 0x2C3;
+constexpr uintptr_t kBGSM_PrecacheGlobalLea = 0x389;
+constexpr uintptr_t kBGSM_PrecacheCall = 0x394;
 
 } // namespace deadworks::offsets
 


### PR DESCRIPTION
## Summary
- Update `BuildGameSessionManifest` byte pattern — compiler reordered instructions after `sub rsp` (old: `?? ?? ?? 48 8D 0D`, new: `4C 8B 02 4C 8B FA 4C 8B E1`)
- Update `AbilityThink` byte pattern — push register sequence changed (`41 55 41 56 41 57` → `56 41 55 41 57`)
- Update `NativeOffsets.hpp` internal offsets for `BuildGameSessionManifest` hero precache resolution (`GetHeroTableCall` 0x306→0x2C3, `PrecacheGlobalLea` 0x33B→0x389, `PrecacheCall` 0x342→0x394)