### PR TITLE
chore: update .gitignore to exclude .vscode and .cursor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.vcxproj.user
 .vs/
 .claude/
+.cursor/
+.vscode/
 x64/
 ~AutoRecover.*
 local.props


### PR DESCRIPTION
Adds `.vscode` and `.cursor` to `.gitignore` to avoid accidentally committing editor-specific config.

I've recently started playing with the codebase and since I daily drive a different IDE, I figured it was worth a small PR to exclude these dirs if you don't mind 😅  saves me and possibly future contributors the hassle of stashing editor settings each time.

Happy to adjust if you have a different preference for handling this