### PR TITLE
chore: update GitHub Actions to use latest action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,21 +12,21 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
 
       - name: Setup .NET 10
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 
       - name: Add MSBuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Cache protobuf
         id: cache-protobuf
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: protobuf-3.21.8
           key: protobuf-3.21.8-msvc-static-mt-v2
@@ -86,7 +86,7 @@ jobs:
           Copy-Item "config/deadworks_mem.jsonc" "$out/game/citadel/cfg/"
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: deadworks-x64-release
           path: artifact/
@@ -100,7 +100,7 @@ jobs:
 
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: deadworks-x64-release
           path: deadworks-x64-release


### PR DESCRIPTION
This pull request updates several GitHub Actions used in the `.github/workflows/build.yml` file to their latest major versions. These changes help ensure continued support, improved features, and security updates for the CI workflow.

**GitHub Actions version upgrades:**

* Updated `actions/checkout` from v4 to v6 for checking out the repository.
* Updated `actions/setup-dotnet` from v4 to v5 for setting up the .NET 10 environment.
* Updated `microsoft/setup-msbuild` from v2 to v3 for adding MSBuild to the PATH.
* Updated `actions/cache` from v4 to v5 for caching protobuf dependencies.
* Updated `actions/upload-artifact` from v4 to v7 for uploading build artifacts.
* Updated `actions/download-artifact` from v4 to v8 for downloading build artifacts.