### PR TITLE
add structured logging, metrics, and traces (MEL + OpenTelemetry)

### DIFF
--- a/managed/ConCommandManager.cs
+++ b/managed/ConCommandManager.cs
@@ -1,5 +1,7 @@
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using DeadworksManaged.Api;
+using DeadworksManaged.Telemetry;
 
 namespace DeadworksManaged;
 
@@ -13,9 +15,11 @@ internal static class ConCommandManager
     private static readonly Dictionary<string, (IDeadworksPlugin plugin, PropertyInfo prop)> _conVars = new(StringComparer.OrdinalIgnoreCase);
 
     private static readonly Lock _lock = new();
+    private static ILogger _logger = null!;
 
     public static void Initialize()
     {
+        _logger = DeadworksTelemetry.CreateLogger("ConCommandManager");
         RegisterBuiltInCommand("dw_reloadconfig", "Reload plugin configs. Usage: dw_reloadconfig [PluginName]", true, OnReloadConfig);
         RegisterBuiltInCommand("dw_plugin", "Manage plugins. Usage: dw_plugin <list|enable|disable|commands> [PluginName]", true, OnPluginCommand);
         RegisterBuiltInCommand("dw_help", "List all available commands.", false, OnHelp);
@@ -36,13 +40,13 @@ internal static class ConCommandManager
             try
             {
                 if (plugin.ReloadConfig())
-                    Console.WriteLine($"[ConfigManager] Reloaded config for {plugin.Name}");
+                    _logger.LogInformation("Reloaded config for {PluginName}", plugin.Name);
                 else
-                    Console.WriteLine($"[ConfigManager] No config to reload for {plugin.Name}");
+                    _logger.LogDebug("No config to reload for {PluginName}", plugin.Name);
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[ConfigManager] Failed to reload config for {plugin.Name}: {ex.Message}");
+                _logger.LogError(ex, "Failed to reload config for {PluginName}", plugin.Name);
             }
         }
     }
@@ -182,7 +186,7 @@ internal static class ConCommandManager
             {
                 if (!ctx.IsServerCommand)
                 {
-                    Console.WriteLine($"[ConCommandManager] Command '{name}' is server-only");
+                    _logger.LogWarning("Command {CommandName} is server-only", name);
                     return;
                 }
                 handler(ctx);
@@ -193,7 +197,7 @@ internal static class ConCommandManager
 
         NativeRegisterConCommand(name, description, BuildConCommandFlags(serverOnly));
 
-        Console.WriteLine($"[ConCommandManager] Registered built-in concommand: {name}{(serverOnly ? " (server-only)" : "")}");
+        _logger.LogDebug("Registered built-in concommand: {CommandName}{ServerOnly}", name, serverOnly ? " (server-only)" : "");
     }
 
     public static void RegisterPlugin(string normalizedPath, List<IDeadworksPlugin> plugins)
@@ -246,6 +250,12 @@ internal static class ConCommandManager
             handlers = [.. handlers]; // snapshot
         }
 
+        using var activity = DeadworksTracing.Source.StartActivity("command.dispatch");
+        activity?.SetTag("command.name", command);
+        activity?.SetTag("player.slot", playerSlot);
+
+        DeadworksMetrics.CommandsDispatched.Add(1);
+
         var ctx = new ConCommandContext(playerSlot, command, args);
         foreach (var handler in handlers)
         {
@@ -255,7 +265,7 @@ internal static class ConCommandManager
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[ConCommandManager] Handler for '{command}' threw: {ex.Message}");
+                _logger.LogError(ex, "Handler for command {CommandName} threw", command);
             }
         }
     }
@@ -303,7 +313,7 @@ internal static class ConCommandManager
                     {
                         if (!ctx.IsServerCommand)
                         {
-                            Console.WriteLine($"[ConCommandManager] Command '{attr.Name}' is server-only");
+                            _logger.LogWarning("Command {CommandName} is server-only", attr.Name);
                             return;
                         }
                         del(ctx);
@@ -316,7 +326,7 @@ internal static class ConCommandManager
 
                 NativeRegisterConCommand(attr.Name, attr.Description, BuildConCommandFlags(serverOnly));
 
-                Console.WriteLine($"[ConCommandManager] Registered concommand: {plugin.Name} -> {attr.Name}{(serverOnly ? " (server-only)" : "")}");
+                _logger.LogDebug("Registered concommand: {PluginName} -> {CommandName}{ServerOnly}", plugin.Name, attr.Name, serverOnly ? " (server-only)" : "");
             }
         }
     }
@@ -334,7 +344,7 @@ internal static class ConCommandManager
 
             if (!prop.CanRead || !prop.CanWrite)
             {
-                Console.WriteLine($"[ConCommandManager] Warning: ConVar '{attr.Name}' on {plugin.Name} must have both getter and setter, skipping");
+                _logger.LogWarning("ConVar {ConVarName} on {PluginName} must have both getter and setter, skipping", attr.Name, plugin.Name);
                 continue;
             }
 
@@ -346,7 +356,7 @@ internal static class ConCommandManager
             {
                 if (serverOnly && !ctx.IsServerCommand)
                 {
-                    Console.WriteLine($"[ConCommandManager] ConVar '{attr.Name}' is server-only");
+                    _logger.LogWarning("ConVar {ConVarName} is server-only", attr.Name);
                     return;
                 }
 
@@ -368,7 +378,7 @@ internal static class ConCommandManager
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[ConCommandManager] Failed to set '{attr.Name}': {ex.Message}");
+                    _logger.LogError(ex, "Failed to set ConVar {ConVarName}", attr.Name);
                 }
             };
 
@@ -383,7 +393,7 @@ internal static class ConCommandManager
 
             NativeRegisterConCommand(attr.Name, attr.Description, BuildConCommandFlags(serverOnly));
 
-            Console.WriteLine($"[ConCommandManager] Registered convar: {plugin.Name} -> {attr.Name} ({prop.PropertyType.Name}){(serverOnly ? " (server-only)" : "")}");
+            _logger.LogDebug("Registered convar: {PluginName} -> {ConVarName} ({TypeName}){ServerOnly}", plugin.Name, attr.Name, prop.PropertyType.Name, serverOnly ? " (server-only)" : "");
         }
     }
 

--- a/managed/ConfigManager.cs
+++ b/managed/ConfigManager.cs
@@ -1,11 +1,14 @@
 using System.Reflection;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using DeadworksManaged.Api;
+using DeadworksManaged.Telemetry;
 
 namespace DeadworksManaged;
 
 internal static class ConfigManager
 {
+	private static ILogger _logger = null!;
 	private static string _configsDir = "";
 
 	private static readonly JsonSerializerOptions JsonOptions = new()
@@ -17,6 +20,8 @@ internal static class ConfigManager
 
 	public static void Initialize()
 	{
+		_logger = DeadworksTelemetry.CreateLogger("ConfigManager");
+
 		// Configs live as a sibling of managed/ (e.g. game/bin/win64/configs/)
 		// so they survive the post-build rmdir of managed/.
 		var managedDir = Path.GetDirectoryName(typeof(ConfigManager).Assembly.Location);
@@ -50,7 +55,7 @@ internal static class ConfigManager
 		}
 		catch (Exception ex)
 		{
-			Console.WriteLine($"[ConfigManager] {plugin.Name}.OnConfigReloaded() threw: {ex.Message}");
+			_logger.LogError(ex, "{PluginName}.OnConfigReloaded() threw", plugin.Name);
 		}
 
 		return true;
@@ -82,11 +87,11 @@ internal static class ConfigManager
 				Directory.CreateDirectory(dir);
 				var json = JsonSerializer.Serialize(config, configType, JsonOptions);
 				File.WriteAllText(filePath, $"// Configuration for {plugin.Name}\n{json}\n");
-				Console.WriteLine($"[ConfigManager] Created default config for {plugin.Name}: {filePath}");
+				_logger.LogInformation("Created default config for {PluginName}: {ConfigPath}", plugin.Name, filePath);
 			}
 			catch (Exception ex)
 			{
-				Console.WriteLine($"[ConfigManager] Failed to write default config for {plugin.Name}: {ex.Message}");
+				_logger.LogError(ex, "Failed to write default config for {PluginName}", plugin.Name);
 			}
 		}
 		else
@@ -99,7 +104,7 @@ internal static class ConfigManager
 			}
 			catch (Exception ex)
 			{
-				Console.WriteLine($"[ConfigManager] Failed to parse config for {plugin.Name}: {ex.Message}");
+				_logger.LogError(ex, "Failed to parse config for {PluginName}", plugin.Name);
 				if (isReload)
 					return false;
 				config = Activator.CreateInstance(configType);
@@ -114,7 +119,7 @@ internal static class ConfigManager
 			}
 			catch (Exception ex)
 			{
-				Console.WriteLine($"[ConfigManager] {plugin.Name} config Validate() threw: {ex.Message}");
+				_logger.LogError(ex, "{PluginName} config Validate() threw", plugin.Name);
 				if (isReload)
 					return false;
 				config = Activator.CreateInstance(configType);

--- a/managed/DeadworksConfig.cs
+++ b/managed/DeadworksConfig.cs
@@ -3,6 +3,36 @@ using System.Text.Json.Serialization;
 
 namespace DeadworksManaged;
 
+internal class TelemetryConfig
+{
+    [JsonPropertyName("enabled")]
+    public bool Enabled { get; set; } = false;
+
+    [JsonPropertyName("otlp_endpoint")]
+    public string OtlpEndpoint { get; set; } = "http://localhost:4317";
+
+    [JsonPropertyName("otlp_protocol")]
+    public string OtlpProtocol { get; set; } = "grpc";
+
+    [JsonPropertyName("export_interval_ms")]
+    public int ExportIntervalMs { get; set; } = 15000;
+
+    [JsonPropertyName("service_name")]
+    public string ServiceName { get; set; } = "deadworks-server";
+
+    [JsonPropertyName("log_level")]
+    public string LogLevel { get; set; } = "Information";
+
+    [JsonPropertyName("enable_traces")]
+    public bool EnableTraces { get; set; } = true;
+
+    [JsonPropertyName("enable_metrics")]
+    public bool EnableMetrics { get; set; } = true;
+
+    [JsonPropertyName("trace_sampling_ratio")]
+    public double TraceSamplingRatio { get; set; } = 1.0;
+}
+
 internal class ServerBrowserConfig
 {
     [JsonPropertyName("api_url")]
@@ -25,6 +55,9 @@ internal class DeadworksConfigRoot
 {
     [JsonPropertyName("serverbrowser")]
     public ServerBrowserConfig ServerBrowser { get; set; } = new();
+
+    [JsonPropertyName("telemetry")]
+    public TelemetryConfig Telemetry { get; set; } = new();
 }
 
 internal static class DeadworksConfig
@@ -40,6 +73,7 @@ internal static class DeadworksConfig
     private static string _configPath = "";
 
     public static ServerBrowserConfig ServerBrowser => _root.ServerBrowser;
+    public static TelemetryConfig Telemetry => _root.Telemetry;
 
     public static void Initialize()
     {

--- a/managed/DeadworksManaged.Api/DeadworksManaged.Api.csproj
+++ b/managed/DeadworksManaged.Api/DeadworksManaged.Api.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <PackageReference Include="Google.Protobuf" Version="3.29.3" />
     <PackageReference Include="Grpc.Tools" Version="2.69.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/managed/DeadworksManaged.Api/DeadworksPluginBase.cs
+++ b/managed/DeadworksManaged.Api/DeadworksPluginBase.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace DeadworksManaged.Api;
 
 /// <summary>
@@ -11,6 +13,9 @@ public abstract class DeadworksPluginBase : IDeadworksPlugin {
 
 	/// <summary>Per-plugin timer service.</summary>
 	protected ITimer Timer => TimerResolver.Get(this);
+
+	/// <summary>Per-plugin logger. Uses the plugin's <see cref="Name"/> as the log category.</summary>
+	protected ILogger Logger => LogResolver.Get(this);
 
 	public virtual void OnPrecacheResources() { }
 	public virtual void OnStartupServer() { }

--- a/managed/DeadworksManaged.Api/IDeadworksPlugin.cs
+++ b/managed/DeadworksManaged.Api/IDeadworksPlugin.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace DeadworksManaged.Api;
 
 /// <summary>
@@ -16,6 +18,11 @@ public interface IDeadworksPlugin {
 	/// Per-plugin timer service. Use to schedule delayed or repeating actions.
 	/// </summary>
 	ITimer Timer => TimerResolver.Get(this);
+
+	/// <summary>
+	/// Per-plugin logger instance. Uses the plugin's <see cref="Name"/> as the log category.
+	/// </summary>
+	ILogger Logger => LogResolver.Get(this);
 
 	/// <summary>
 	/// Called during map load to precache resources (particles, models, etc).

--- a/managed/DeadworksManaged.Api/Logging/LogResolver.cs
+++ b/managed/DeadworksManaged.Api/Logging/LogResolver.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.Logging;
+
+namespace DeadworksManaged.Api;
+
+/// <summary>
+/// Internal resolver used by the IDeadworksPlugin.Logger default property.
+/// Set up by the host during initialization.
+/// </summary>
+internal static class LogResolver
+{
+    internal static Func<IDeadworksPlugin, ILogger>? Resolve;
+
+    public static ILogger Get(IDeadworksPlugin plugin)
+    {
+        if (Resolve == null)
+            throw new InvalidOperationException("Logging system not initialized.");
+        return Resolve(plugin);
+    }
+}

--- a/managed/DeadworksManaged.csproj
+++ b/managed/DeadworksManaged.csproj
@@ -20,6 +20,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.5" />
+    <PackageReference Include="OpenTelemetry" Version="1.12.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="DeadworksManaged.Api\DeadworksManaged.Api.csproj" />
   </ItemGroup>
 

--- a/managed/EntryPoint.cs
+++ b/managed/EntryPoint.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using System.Text;
 using DeadworksManaged.Api;
+using DeadworksManaged.Telemetry;
 using Google.Protobuf;
 
 namespace DeadworksManaged;
@@ -12,8 +13,14 @@ public static class EntryPoint
     {
         var callbacks = (NativeCallbacks*)callbacksPtr;
 
-        Console.SetOut(new NativeLogWriter((delegate* unmanaged[Cdecl]<char*, void>)callbacks->Log));
+        var logCallback = (delegate* unmanaged[Cdecl]<char*, void>)callbacks->Log;
+
+        // Keep Console.SetOut for backward compatibility (stray Console.WriteLines)
+        Console.SetOut(new NativeLogWriter(logCallback));
         Console.WriteLine("Hello from .NET 10!");
+
+        // Store native log callback for the telemetry system's NativeEngineLoggerProvider
+        NativeLogCallback.Set(logCallback);
 
         NativeInterop.Bind(callbacks);
         CheatCommandGate.ApplyCheatFlag();

--- a/managed/PluginLoader.ChatCommands.cs
+++ b/managed/PluginLoader.ChatCommands.cs
@@ -1,5 +1,7 @@
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using DeadworksManaged.Api;
+using DeadworksManaged.Telemetry;
 
 namespace DeadworksManaged;
 
@@ -9,6 +11,7 @@ internal static partial class PluginLoader
 
     public static HookResult DispatchChatMessage(ChatMessage message)
     {
+        DeadworksMetrics.ChatMessagesProcessed.Add(1);
         var result = HookResult.Continue;
 
         var text = message.ChatText.Trim();
@@ -37,7 +40,7 @@ internal static partial class PluginLoader
                     }
                     catch (Exception ex)
                     {
-                        Console.WriteLine($"[PluginLoader] Chat command handler for '/{commandName}' threw: {ex.Message}");
+                        _logger.LogError(ex, "Chat command handler for /{CommandName} threw", commandName);
                     }
                 }
 
@@ -71,7 +74,7 @@ internal static partial class PluginLoader
 
                     _chatCommandRegistry.AddForPlugin(normalizedPath, attr.Command, del);
                     PluginRegistrationTracker.Add(normalizedPath, "chat", $"/{attr.Command}");
-                    Console.WriteLine($"[PluginLoader] Registered chat command: {plugin.Name} -> /{attr.Command}");
+                    _logger.LogDebug("Registered chat command: {PluginName} -> /{CommandName}", plugin.Name, attr.Command);
                 }
             }
         }

--- a/managed/PluginLoader.EntityIO.cs
+++ b/managed/PluginLoader.EntityIO.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using DeadworksManaged.Api;
+using DeadworksManaged.Telemetry;
 
 namespace DeadworksManaged;
 

--- a/managed/PluginLoader.Events.cs
+++ b/managed/PluginLoader.Events.cs
@@ -1,5 +1,7 @@
 using System.Reflection;
+using Microsoft.Extensions.Logging;
 using DeadworksManaged.Api;
+using DeadworksManaged.Telemetry;
 
 namespace DeadworksManaged;
 
@@ -53,7 +55,7 @@ internal static partial class PluginLoader
                         RegisterEventWithNative(attr.EventName);
 
                     PluginRegistrationTracker.Add(normalizedPath, "event", attr.EventName);
-                    Console.WriteLine($"[PluginLoader] Registered game event handler: {plugin.Name} -> {attr.EventName}");
+                    _logger.LogDebug("Registered game event handler: {PluginName} -> {EventName}", plugin.Name, attr.EventName);
                 }
             }
         }
@@ -95,6 +97,8 @@ internal static partial class PluginLoader
         if (handlers == null)
             return HookResult.Continue;
 
+        DeadworksMetrics.EventsDispatched.Add(1);
+
         var result = HookResult.Continue;
         foreach (var handler in handlers)
         {
@@ -105,7 +109,8 @@ internal static partial class PluginLoader
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[PluginLoader] Game event handler for '{name}' threw: {ex.Message}");
+                _logger.LogError(ex, "Game event handler for {EventName} threw", name);
+                DeadworksMetrics.EventHandlerErrors.Add(1);
             }
         }
 

--- a/managed/PluginLoader.NetMessages.cs
+++ b/managed/PluginLoader.NetMessages.cs
@@ -1,6 +1,8 @@
 using System.Reflection;
 using Google.Protobuf;
+using Microsoft.Extensions.Logging;
 using DeadworksManaged.Api;
+using DeadworksManaged.Telemetry;
 
 namespace DeadworksManaged;
 
@@ -95,7 +97,7 @@ internal static partial class PluginLoader
                 int msgId = NetMessageRegistry.GetMessageId(protoType);
                 if (msgId < 0)
                 {
-                    Console.WriteLine($"[PluginLoader] Warning: no message ID found for {protoType.Name} in {plugin.Name}.{method.Name}, skipping");
+                    _logger.LogWarning("No message ID found for {ProtoType} in {PluginName}.{MethodName}, skipping", protoType.Name, plugin.Name, method.Name);
                     continue;
                 }
 
@@ -112,7 +114,7 @@ internal static partial class PluginLoader
                     dict[msgId] = list;
                 }
                 list.Add(del);
-                Console.WriteLine($"[PluginLoader] Registered net message handler: {plugin.Name}.{method.Name} -> {protoType.Name} msgId={msgId} ({direction})");
+                _logger.LogDebug("Registered net message handler: {PluginName}.{MethodName} -> {ProtoType} msgId={MsgId} ({Direction})", plugin.Name, method.Name, protoType.Name, msgId, direction);
             }
         }
 
@@ -177,7 +179,7 @@ internal static partial class PluginLoader
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[PluginLoader] Net message outgoing handler for msgId={msgId} threw: {ex.Message}");
+                _logger.LogError(ex, "Net message outgoing handler for msgId={MsgId} threw", msgId);
             }
         }
 
@@ -225,7 +227,7 @@ internal static partial class PluginLoader
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[PluginLoader] Net message incoming handler for msgId={msgId} threw: {ex.Message}");
+                _logger.LogError(ex, "Net message incoming handler for msgId={MsgId} threw", msgId);
             }
         }
 

--- a/managed/PluginLoader.cs
+++ b/managed/PluginLoader.cs
@@ -1,7 +1,10 @@
+using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.Loader;
 using Google.Protobuf;
+using Microsoft.Extensions.Logging;
 using DeadworksManaged.Api;
+using DeadworksManaged.Telemetry;
 
 namespace DeadworksManaged;
 
@@ -81,13 +84,23 @@ internal static partial class PluginLoader
         var protobufAsm = typeof(IMessage).Assembly;
         map[protobufAsm.GetName().Name!] = protobufAsm;
 
+        // Microsoft.Extensions.Logging.Abstractions - shared so plugins use the same ILogger type
+        var loggingAsm = typeof(ILogger).Assembly;
+        map[loggingAsm.GetName().Name!] = loggingAsm;
+
         return map;
     }
 
+    private static ILogger _logger = null!;
+
     public static void LoadAll()
     {
-        TimerRegistry.Initialize();
         DeadworksConfig.Initialize();
+        DeadworksTelemetry.Initialize();
+        PluginLoggerRegistry.Initialize();
+        _logger = DeadworksTelemetry.CreateLogger("PluginLoader");
+
+        TimerRegistry.Initialize();
         ConfigManager.Initialize();
         ConCommandManager.Initialize();
         ServerBrowser.Initialize();
@@ -112,19 +125,19 @@ internal static partial class PluginLoader
         _pluginsDir = Path.Combine(baseDir, "plugins");
         if (!Directory.Exists(_pluginsDir))
         {
-            Console.WriteLine($"[PluginLoader] No plugins directory found at: {_pluginsDir}");
+            _logger.LogWarning("No plugins directory found at {PluginsDir}", _pluginsDir);
             return;
         }
 
         var dlls = Directory.GetFiles(_pluginsDir, "*.dll");
-        Console.WriteLine($"[PluginLoader] Scanning {_pluginsDir} ({dlls.Length} DLLs found)");
+        _logger.LogInformation("Scanning {PluginsDir} ({DllCount} DLLs found)", _pluginsDir, dlls.Length);
 
         foreach (var dll in dlls)
         {
             var dllName = Path.GetFileNameWithoutExtension(dll);
             if (!PluginStateManager.IsEnabled(dllName))
             {
-                Console.WriteLine($"[PluginLoader] Skipping disabled plugin: {dllName}");
+                _logger.LogDebug("Skipping disabled plugin {PluginName}", dllName);
                 continue;
             }
 
@@ -134,9 +147,21 @@ internal static partial class PluginLoader
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[PluginLoader] Failed to load {Path.GetFileName(dll)}: {ex.Message}");
+                _logger.LogError(ex, "Failed to load plugin {DllName}", Path.GetFileName(dll));
+                DeadworksMetrics.PluginLoadErrors.Add(1);
             }
         }
+
+        // Register observable gauges now that plugin loading is complete
+        DeadworksMetrics.RegisterObservableGauges(
+            () => _pluginSnapshot.Length,
+            () =>
+            {
+                int count = 0;
+                for (int i = 0; i < Players.MaxSlot; i++)
+                    if (Players.IsConnected(i)) count++;
+                return count;
+            });
 
         StartWatching(_pluginsDir);
     }
@@ -165,7 +190,7 @@ internal static partial class PluginLoader
         var dllPath = Path.Combine(_pluginsDir, dllName + ".dll");
         if (!File.Exists(dllPath))
         {
-            Console.WriteLine($"[PluginLoader] Cannot enable '{dllName}': DLL not found in plugins directory");
+            _logger.LogWarning("Cannot enable plugin {PluginName}: DLL not found in plugins directory", dllName);
             return;
         }
 
@@ -174,7 +199,7 @@ internal static partial class PluginLoader
         {
             if (_loaded.ContainsKey(normalizedPath))
             {
-                Console.WriteLine($"[PluginLoader] Plugin '{dllName}' is already loaded");
+                _logger.LogInformation("Plugin {PluginName} is already loaded", dllName);
                 return;
             }
         }
@@ -185,7 +210,7 @@ internal static partial class PluginLoader
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"[PluginLoader] Failed to enable '{dllName}': {ex.Message}");
+            _logger.LogError(ex, "Failed to enable plugin {PluginName}", dllName);
         }
     }
 
@@ -201,6 +226,13 @@ internal static partial class PluginLoader
     private static void LoadPlugin(string dllPath, bool isReload)
     {
         var normalizedPath = Path.GetFullPath(dllPath);
+        var pluginFileName = Path.GetFileNameWithoutExtension(dllPath);
+
+        using var activity = DeadworksTracing.Source.StartActivity("plugin.load");
+        activity?.SetTag("plugin.name", pluginFileName);
+        activity?.SetTag("is_reload", isReload);
+
+        var sw = Stopwatch.StartNew();
         var context = new PluginLoadContext(normalizedPath, SharedAssemblies);
 
         // Load DLL from memory so the file isn't locked by the runtime.
@@ -227,14 +259,15 @@ internal static partial class PluginLoader
         {
             if (Activator.CreateInstance(type) is IDeadworksPlugin plugin)
             {
-                // Create and register timer service before OnLoad so it's available immediately
+                // Create and register services before OnLoad so they're available immediately
                 var timerService = new TimerService();
                 TimerRegistry.Register(plugin, timerService);
+                PluginLoggerRegistry.Register(plugin);
 
                 ConfigManager.LoadConfig(plugin);
                 plugin.OnLoad(isReload);
                 plugins.Add(plugin);
-                Console.WriteLine($"[PluginLoader] Loaded plugin: {plugin.Name}{(isReload ? " (reloaded)" : "")}");
+                _logger.LogInformation("Loaded plugin {PluginName} (reload: {IsReload})", plugin.Name, isReload);
             }
         }
 
@@ -249,10 +282,19 @@ internal static partial class PluginLoader
             ConCommandManager.RegisterPlugin(normalizedPath, plugins);
             Commands.CommandRegistration.RegisterPluginCommands(normalizedPath, plugins, _chatCommandRegistry);
         }
+
+        sw.Stop();
+        DeadworksMetrics.PluginLoadDuration.Record(sw.Elapsed.TotalMilliseconds,
+            new KeyValuePair<string, object?>("plugin.name", pluginFileName));
+        DeadworksMetrics.PluginsLoaded.Add(1,
+            new KeyValuePair<string, object?>("plugin.name", pluginFileName));
     }
 
     private static void UnloadPlugin(string normalizedPath)
     {
+        using var activity = DeadworksTracing.Source.StartActivity("plugin.unload");
+        activity?.SetTag("plugin.name", Path.GetFileNameWithoutExtension(normalizedPath));
+
         PluginEntry? entry;
         lock (_lock)
         {
@@ -276,15 +318,17 @@ internal static partial class PluginLoader
                 TimerRegistry.Unregister(plugin);
 
                 plugin.OnUnload();
-                Console.WriteLine($"[PluginLoader] Unloaded plugin: {plugin.Name}");
+                PluginLoggerRegistry.Unregister(plugin);
+                _logger.LogInformation("Unloaded plugin {PluginName}", plugin.Name);
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[PluginLoader] Error unloading {plugin.Name}: {ex.Message}");
+                _logger.LogError(ex, "Error unloading plugin {PluginName}", plugin.Name);
             }
         }
 
         entry.Context.Unload();
+        DeadworksMetrics.PluginsUnloaded.Add(1);
     }
 
     // --- File watcher ---
@@ -302,7 +346,7 @@ internal static partial class PluginLoader
         _watcher.Changed += OnDllChanged;
         _watcher.Created += OnDllChanged;
 
-        Console.WriteLine($"[PluginLoader] Watching for plugin changes in: {pluginsDir}");
+        _logger.LogInformation("Watching for plugin changes in {PluginsDir}", pluginsDir);
     }
 
     private static void OnDllChanged(object sender, FileSystemEventArgs e)
@@ -329,19 +373,20 @@ internal static partial class PluginLoader
             var dllName = Path.GetFileNameWithoutExtension(dllPath);
             if (!PluginStateManager.IsEnabled(dllName))
             {
-                Console.WriteLine($"[PluginLoader] Skipping reload of disabled plugin: {dllName}");
+                _logger.LogDebug("Skipping reload of disabled plugin {PluginName}", dllName);
                 continue;
             }
 
             try
             {
-                Console.WriteLine($"[PluginLoader] Detected change: {Path.GetFileName(dllPath)}");
+                _logger.LogInformation("Detected change for {DllName}, reloading", Path.GetFileName(dllPath));
                 UnloadPlugin(dllPath);
                 LoadPlugin(dllPath, isReload: true);
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[PluginLoader] Failed to reload {Path.GetFileName(dllPath)}: {ex.Message}");
+                _logger.LogError(ex, "Failed to reload plugin {DllName}", Path.GetFileName(dllPath));
+                DeadworksMetrics.PluginLoadErrors.Add(1);
             }
         }
     }
@@ -365,7 +410,9 @@ internal static partial class PluginLoader
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[PluginLoader] {plugin.Name}.{methodName} threw: {ex.Message}");
+                _logger.LogError(ex, "Plugin {PluginName}.{MethodName} threw", plugin.Name, methodName);
+                DeadworksMetrics.EventHandlerErrors.Add(1,
+                    new KeyValuePair<string, object?>("plugin.name", plugin.Name));
             }
         }
     }
@@ -383,7 +430,9 @@ internal static partial class PluginLoader
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[PluginLoader] {plugin.Name}.{methodName} threw: {ex.Message}");
+                _logger.LogError(ex, "Plugin {PluginName}.{MethodName} threw", plugin.Name, methodName);
+                DeadworksMetrics.EventHandlerErrors.Add(1,
+                    new KeyValuePair<string, object?>("plugin.name", plugin.Name));
             }
         }
         return result;
@@ -396,19 +445,41 @@ internal static partial class PluginLoader
 
     public static void DispatchStartupServer()
     {
+        using var activity = DeadworksTracing.Source.StartActivity("server.startup");
+        activity?.SetTag("map.name", Server.MapName);
+
         TimerRegistry.CancelAllMapChangeTimers();
         ServerBrowser.OnStartupServer();
         DispatchToPlugins(p => p.OnStartupServer(), nameof(IDeadworksPlugin.OnStartupServer));
+        _logger.LogInformation("Server started on map {MapName}", Server.MapName);
     }
+
+    private static readonly Stopwatch _frameStopwatch = new();
+    private static int _frameCounter;
 
     public static void DispatchGameFrame(bool simulating, bool firstTick, bool lastTick)
     {
+        _frameStopwatch.Restart();
         TimerEngine.OnTick();
         DispatchToPlugins(p => p.OnGameFrame(simulating, firstTick, lastTick), nameof(IDeadworksPlugin.OnGameFrame));
+        _frameStopwatch.Stop();
+
+        // Sample every 64th frame to avoid histogram overhead at ~64Hz
+        if (++_frameCounter >= 64)
+        {
+            _frameCounter = 0;
+            DeadworksMetrics.GameFrameDuration.Record(_frameStopwatch.Elapsed.TotalMilliseconds);
+        }
     }
 
     public static bool DispatchClientConnect(ClientConnectEvent args)
     {
+        using var activity = DeadworksTracing.Source.StartActivity("client.connect");
+        activity?.SetTag("player.slot", args.Slot);
+        activity?.SetTag("player.steamid", args.SteamId);
+
+        DeadworksMetrics.PlayerConnections.Add(1);
+
         var snapshot = _pluginSnapshot;
         bool allowed = true;
         foreach (var plugin in snapshot)
@@ -420,9 +491,22 @@ internal static partial class PluginLoader
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[PluginLoader] {plugin.Name}.OnClientConnect threw: {ex.Message}");
+                _logger.LogError(ex, "Plugin {PluginName}.OnClientConnect threw", plugin.Name);
+                DeadworksMetrics.EventHandlerErrors.Add(1,
+                    new KeyValuePair<string, object?>("plugin.name", plugin.Name));
             }
         }
+
+        if (!allowed)
+        {
+            DeadworksMetrics.PlayerConnectionsRejected.Add(1);
+            _logger.LogInformation("Client connection rejected (slot={Slot}, steamid={SteamId})", args.Slot, args.SteamId);
+        }
+        else
+        {
+            _logger.LogInformation("Client connected (slot={Slot}, steamid={SteamId}, name={Name})", args.Slot, args.SteamId, args.Name);
+        }
+
         return allowed;
     }
 
@@ -433,7 +517,16 @@ internal static partial class PluginLoader
         => DispatchToPlugins(p => p.OnClientFullConnect(args), nameof(IDeadworksPlugin.OnClientFullConnect));
 
     public static void DispatchClientDisconnect(ClientDisconnectedEvent args)
-        => DispatchToPlugins(p => p.OnClientDisconnect(args), nameof(IDeadworksPlugin.OnClientDisconnect));
+    {
+        using var activity = DeadworksTracing.Source.StartActivity("client.disconnect");
+        activity?.SetTag("player.slot", args.Slot);
+        activity?.SetTag("disconnect.reason", args.Reason);
+
+        DeadworksMetrics.PlayerDisconnections.Add(1);
+        _logger.LogInformation("Client disconnected (slot={Slot}, reason={Reason})", args.Slot, args.Reason);
+
+        DispatchToPlugins(p => p.OnClientDisconnect(args), nameof(IDeadworksPlugin.OnClientDisconnect));
+    }
 
     public static void DispatchEntityCreated(EntityCreatedEvent args)
         => DispatchToPlugins(p => p.OnEntityCreated(args), nameof(IDeadworksPlugin.OnEntityCreated));
@@ -521,15 +614,18 @@ internal static partial class PluginLoader
                 try
                 {
                     plugin.OnUnload();
-                    Console.WriteLine($"[PluginLoader] Unloaded plugin: {plugin.Name}");
+                    _logger.LogInformation("Unloaded plugin {PluginName}", plugin.Name);
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"[PluginLoader] Error unloading {plugin.Name}: {ex.Message}");
+                    _logger.LogError(ex, "Error unloading plugin {PluginName}", plugin.Name);
                 }
             }
 
             entry.Context.Unload();
         }
+
+        PluginLoggerRegistry.Clear();
+        DeadworksTelemetry.Shutdown();
     }
 }

--- a/managed/PluginStateManager.cs
+++ b/managed/PluginStateManager.cs
@@ -1,9 +1,12 @@
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using DeadworksManaged.Telemetry;
 
 namespace DeadworksManaged;
 
 internal static class PluginStateManager
 {
+    private static ILogger _logger = null!;
     private static string _filePath = "";
     private static Dictionary<string, bool> _states = new(StringComparer.OrdinalIgnoreCase);
 
@@ -15,6 +18,7 @@ internal static class PluginStateManager
 
     public static void Initialize()
     {
+        _logger = DeadworksTelemetry.CreateLogger("PluginStateManager");
         var managedDir = Path.GetDirectoryName(typeof(PluginStateManager).Assembly.Location);
         var configsDir = Path.GetFullPath(Path.Combine(managedDir!, "..", "configs"));
         _filePath = Path.Combine(configsDir, "plugins.jsonc");
@@ -45,7 +49,7 @@ internal static class PluginStateManager
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"[PluginStateManager] Failed to load {_filePath}: {ex.Message}");
+            _logger.LogError(ex, "Failed to load plugin state from {FilePath}", _filePath);
         }
     }
 
@@ -65,7 +69,7 @@ internal static class PluginStateManager
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"[PluginStateManager] Failed to save {_filePath}: {ex.Message}");
+            _logger.LogError(ex, "Failed to save plugin state to {FilePath}", _filePath);
         }
     }
 }

--- a/managed/ServerBrowser.cs
+++ b/managed/ServerBrowser.cs
@@ -1,7 +1,10 @@
+using System.Diagnostics;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
 using DeadworksManaged.Api;
+using DeadworksManaged.Telemetry;
 
 namespace DeadworksManaged;
 
@@ -24,6 +27,7 @@ internal static class ServerBrowser
         PropertyNameCaseInsensitive = true
     };
 
+    private static ILogger _logger = null!;
     private static ServerBrowserConfig _config = null!;
     private static ServerCredentials? _credentials;
     private static Timer? _heartbeatTimer;
@@ -33,13 +37,15 @@ internal static class ServerBrowser
 
     public static void Initialize()
     {
+        _logger = DeadworksTelemetry.CreateLogger("ServerBrowser");
+
         var managedDir = Path.GetDirectoryName(typeof(ServerBrowser).Assembly.Location);
         _credentialsDir = Path.GetFullPath(Path.Combine(managedDir!, "..", "configs", "ServerBrowser"));
         _config = DeadworksConfig.ServerBrowser;
 
         if (_config.Unlisted || Server.HasCommandLineParm("-nomaster"))
         {
-            Console.WriteLine("[ServerBrowser] Server is unlisted - heartbeat disabled.");
+            _logger.LogInformation("Server is unlisted - heartbeat disabled");
             return;
         }
 
@@ -78,11 +84,11 @@ internal static class ServerBrowser
                 if (!string.IsNullOrEmpty(name)) _serverName = name;
             }
 
-            Console.WriteLine($"[ServerBrowser] Port: {_gamePort}, name: {_serverName}");
+            _logger.LogInformation("Resolved server config (port={Port}, name={ServerName})", _gamePort, _serverName);
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"[ServerBrowser] Failed to resolve convars: {ex.Message}");
+            _logger.LogError(ex, "Failed to resolve convars");
         }
     }
 
@@ -99,14 +105,14 @@ internal static class ServerBrowser
                 _credentials = JsonSerializer.Deserialize<ServerCredentials>(json, JsonOptions);
                 if (_credentials != null && !string.IsNullOrEmpty(_credentials.ServerId) && !string.IsNullOrEmpty(_credentials.ServerToken))
                 {
-                    Console.WriteLine($"[ServerBrowser] Loaded credentials (id: {_credentials.ServerId})");
+                    _logger.LogInformation("Loaded credentials (serverId={ServerId})", _credentials.ServerId);
                     StartHeartbeat();
                     return;
                 }
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[ServerBrowser] Failed to read credentials: {ex.Message}");
+                _logger.LogError(ex, "Failed to read credentials");
             }
         }
 
@@ -123,13 +129,15 @@ internal static class ServerBrowser
         else
         {
             // Registration failed - start the heartbeat timer anyway so it retries
-            Console.WriteLine("[ServerBrowser] Will retry registration on next heartbeat tick.");
+            _logger.LogWarning("Will retry registration on next heartbeat tick");
             StartHeartbeat();
         }
     }
 
     private static async Task<bool> TryRegister(string credPath)
     {
+        using var activity = DeadworksTracing.Source.StartActivity("heartbeat.register");
+
         try
         {
             var url = $"{_config.ApiUrl.TrimEnd('/')}/api/servers/register";
@@ -143,7 +151,8 @@ internal static class ServerBrowser
             var response = await Http.PostAsJsonAsync(url, payload);
             if (!response.IsSuccessStatusCode)
             {
-                Console.WriteLine($"[ServerBrowser] Auto-registration failed: HTTP {(int)response.StatusCode}");
+                _logger.LogWarning("Auto-registration failed: HTTP {StatusCode}", (int)response.StatusCode);
+                activity?.SetStatus(ActivityStatusCode.Error, $"HTTP {(int)response.StatusCode}");
                 return false;
             }
 
@@ -153,12 +162,13 @@ internal static class ServerBrowser
 
             _credentials = new ServerCredentials { ServerId = id, ServerToken = token };
             SaveCredentials(credPath);
-            Console.WriteLine($"[ServerBrowser] Auto-registered with API (id: {id})");
+            _logger.LogInformation("Auto-registered with API (serverId={ServerId})", id);
             return true;
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"[ServerBrowser] Auto-registration error: {ex.Message}");
+            _logger.LogError(ex, "Auto-registration error");
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
             return false;
         }
     }
@@ -173,7 +183,7 @@ internal static class ServerBrowser
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"[ServerBrowser] Failed to save credentials: {ex.Message}");
+            _logger.LogError(ex, "Failed to save credentials");
         }
     }
 
@@ -200,6 +210,12 @@ internal static class ServerBrowser
             return;
         }
 
+        using var activity = DeadworksTracing.Source.StartActivity("heartbeat.send");
+        activity?.SetTag("server.id", _credentials.ServerId);
+
+        var sw = Stopwatch.StartNew();
+        DeadworksMetrics.HeartbeatsSent.Add(1);
+
         try
         {
             var payload = BuildPayload();
@@ -210,14 +226,23 @@ internal static class ServerBrowser
             request.Content = JsonContent.Create(payload);
 
             var response = await Http.SendAsync(request);
+
             if (!response.IsSuccessStatusCode)
             {
-                Console.WriteLine($"[ServerBrowser] Heartbeat failed: HTTP {(int)response.StatusCode}");
+                _logger.LogWarning("Heartbeat failed: HTTP {StatusCode}", (int)response.StatusCode);
+                DeadworksMetrics.HeartbeatsFailed.Add(1);
+                activity?.SetStatus(ActivityStatusCode.Error, $"HTTP {(int)response.StatusCode}");
             }
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"[ServerBrowser] Heartbeat error: {ex.Message}");
+            DeadworksMetrics.HeartbeatsFailed.Add(1);
+            _logger.LogError(ex, "Heartbeat error");
+            activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+        }
+        finally
+        {
+            DeadworksMetrics.HeartbeatDuration.Record(sw.Elapsed.TotalMilliseconds);
         }
     }
 
@@ -227,15 +252,15 @@ internal static class ServerBrowser
 
         var addons = string.Join(",", _config.ContentAddons);
         Server.SetAddons(addons);
-        Console.WriteLine($"[ServerBrowser] Server addons set to '{addons}'");
+        _logger.LogInformation("Server addons set to {Addons}", addons);
 
         foreach (var addon in _config.ContentAddons)
         {
             var vpkPath = $"deadworks_mods/vpks/{addon}.vpk";
             if (Server.AddSearchPath(vpkPath))
-                Console.WriteLine($"[ServerBrowser] Mounted server addon: {vpkPath}");
+                _logger.LogDebug("Mounted server addon: {VpkPath}", vpkPath);
             else
-                Console.WriteLine($"[ServerBrowser] Failed to mount: {vpkPath}");
+                _logger.LogWarning("Failed to mount addon: {VpkPath}", vpkPath);
         }
     }
 

--- a/managed/Telemetry/DeadworksMetrics.cs
+++ b/managed/Telemetry/DeadworksMetrics.cs
@@ -1,0 +1,84 @@
+using System.Diagnostics.Metrics;
+
+namespace DeadworksManaged.Telemetry;
+
+/// <summary>
+/// All metric instruments for Deadworks game server observability.
+/// Uses <see cref="System.Diagnostics.Metrics"/> which OpenTelemetry hooks into automatically.
+/// </summary>
+internal static class DeadworksMetrics
+{
+    public const string MeterName = "Deadworks.Server";
+    private static readonly Meter Meter = new(MeterName, "1.0.0");
+
+    // --- Plugin Lifecycle ---
+    public static readonly Counter<long> PluginsLoaded = Meter.CreateCounter<long>(
+        "deadworks.plugins.loaded", "count", "Total plugin load operations");
+
+    public static readonly Counter<long> PluginsUnloaded = Meter.CreateCounter<long>(
+        "deadworks.plugins.unloaded", "count", "Total plugin unload operations");
+
+    public static readonly Counter<long> PluginLoadErrors = Meter.CreateCounter<long>(
+        "deadworks.plugins.load_errors", "count", "Plugin load failures");
+
+    public static readonly Histogram<double> PluginLoadDuration = Meter.CreateHistogram<double>(
+        "deadworks.plugins.load_duration_ms", "ms", "Time to load a plugin");
+
+    // Registered lazily in DeadworksTelemetry.Initialize after PluginLoader is available
+    public static ObservableGauge<int>? ActivePluginCount;
+
+    public static void RegisterObservableGauges(Func<int> getActivePlugins, Func<int> getConnectedPlayers)
+    {
+        ActivePluginCount = Meter.CreateObservableGauge(
+            "deadworks.plugins.active", getActivePlugins,
+            "plugins", "Currently active plugins");
+
+        Meter.CreateObservableGauge(
+            "deadworks.players.count", getConnectedPlayers,
+            "players", "Currently connected player count");
+    }
+
+    // --- Player Connections ---
+    public static readonly Counter<long> PlayerConnections = Meter.CreateCounter<long>(
+        "deadworks.players.connections_total", "count", "Total player connections");
+
+    public static readonly Counter<long> PlayerDisconnections = Meter.CreateCounter<long>(
+        "deadworks.players.disconnections_total", "count", "Total player disconnections");
+
+    public static readonly Counter<long> PlayerConnectionsRejected = Meter.CreateCounter<long>(
+        "deadworks.players.connections_rejected", "count", "Rejected connection attempts");
+
+    // --- Frame Performance ---
+    public static readonly Histogram<double> GameFrameDuration = Meter.CreateHistogram<double>(
+        "deadworks.frame.duration_ms", "ms", "Total managed game frame processing time");
+
+    // --- Timer Engine ---
+    public static readonly Histogram<int> TimerTasksPerFrame = Meter.CreateHistogram<int>(
+        "deadworks.timers.tasks_per_frame", "count", "Timer tasks executed per frame");
+
+    public static readonly Counter<long> TimerErrors = Meter.CreateCounter<long>(
+        "deadworks.timers.errors", "count", "Timer callback failures");
+
+    // --- Server Browser / Heartbeat ---
+    public static readonly Counter<long> HeartbeatsSent = Meter.CreateCounter<long>(
+        "deadworks.heartbeat.sent_total", "count", "Heartbeat attempts");
+
+    public static readonly Counter<long> HeartbeatsFailed = Meter.CreateCounter<long>(
+        "deadworks.heartbeat.failed_total", "count", "Failed heartbeats");
+
+    public static readonly Histogram<double> HeartbeatDuration = Meter.CreateHistogram<double>(
+        "deadworks.heartbeat.duration_ms", "ms", "Heartbeat HTTP request duration");
+
+    // --- Event Dispatch ---
+    public static readonly Counter<long> EventsDispatched = Meter.CreateCounter<long>(
+        "deadworks.events.dispatched_total", "count", "Game events dispatched to plugins");
+
+    public static readonly Counter<long> EventHandlerErrors = Meter.CreateCounter<long>(
+        "deadworks.events.handler_errors", "count", "Plugin event handler errors");
+
+    public static readonly Counter<long> ChatMessagesProcessed = Meter.CreateCounter<long>(
+        "deadworks.chat.messages_total", "count", "Chat messages processed");
+
+    public static readonly Counter<long> CommandsDispatched = Meter.CreateCounter<long>(
+        "deadworks.commands.dispatched_total", "count", "Console commands dispatched");
+}

--- a/managed/Telemetry/DeadworksTelemetry.cs
+++ b/managed/Telemetry/DeadworksTelemetry.cs
@@ -1,0 +1,154 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace DeadworksManaged.Telemetry;
+
+/// <summary>
+/// Central telemetry bootstrap. Owns the <see cref="ILoggerFactory"/>, <see cref="MeterProvider"/>,
+/// and <see cref="TracerProvider"/>. Initialized once during server startup.
+/// </summary>
+internal static class DeadworksTelemetry
+{
+    private static ILoggerFactory? _loggerFactory;
+    private static MeterProvider? _meterProvider;
+    private static TracerProvider? _tracerProvider;
+
+    /// <summary>
+    /// Initialize the telemetry system. Must be called after <see cref="DeadworksConfig.Initialize"/>
+    /// and after <see cref="NativeLogCallback.Set"/> has stored the native callback pointer.
+    /// </summary>
+    public static unsafe void Initialize()
+    {
+        var config = DeadworksConfig.Telemetry;
+
+        // Environment variable overrides (standard OTel + Deadworks-specific)
+        var enabled = GetEnvBool("DEADWORKS_TELEMETRY_ENABLED", config.Enabled);
+        var otlpEndpoint = GetEnvString("DEADWORKS_OTLP_ENDPOINT", config.OtlpEndpoint);
+        var otlpProtocol = GetEnvString("DEADWORKS_OTLP_PROTOCOL", config.OtlpProtocol);
+        var serviceName = GetEnvString("DEADWORKS_SERVICE_NAME", config.ServiceName);
+        var logLevelStr = GetEnvString("DEADWORKS_LOG_LEVEL", config.LogLevel);
+
+        if (!Enum.TryParse<LogLevel>(logLevelStr, ignoreCase: true, out var minLogLevel))
+            minLogLevel = LogLevel.Information;
+
+        var exportProtocol = otlpProtocol.Equals("http/protobuf", StringComparison.OrdinalIgnoreCase)
+            ? OtlpExportProtocol.HttpProtobuf
+            : OtlpExportProtocol.Grpc;
+
+        var resourceBuilder = ResourceBuilder.CreateDefault()
+            .AddService(
+                serviceName: serviceName,
+                serviceVersion: typeof(DeadworksTelemetry).Assembly.GetName().Version?.ToString() ?? "0.0.0")
+            .AddAttributes([
+                new KeyValuePair<string, object>("host.name", Environment.MachineName),
+            ]);
+
+        Action<OtlpExporterOptions> configureOtlp = otlp =>
+        {
+            otlp.Endpoint = new Uri(otlpEndpoint);
+            otlp.Protocol = exportProtocol;
+        };
+
+        // --- Logging ---
+        var loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder.SetMinimumLevel(minLogLevel);
+
+            // Always add native engine provider (writes to game console)
+            var nativeCallback = NativeLogCallback.Callback;
+            if (nativeCallback != null)
+            {
+                builder.AddProvider(new NativeEngineLoggerProvider(nativeCallback, minLogLevel));
+            }
+
+            // Add OTLP log exporter if telemetry is enabled
+            if (enabled)
+            {
+                builder.AddOpenTelemetry(options =>
+                {
+                    options.SetResourceBuilder(resourceBuilder);
+                    options.IncludeScopes = true;
+                    options.IncludeFormattedMessage = true;
+                    options.AddOtlpExporter(configureOtlp);
+                });
+            }
+        });
+
+        _loggerFactory = loggerFactory;
+
+        // --- Metrics ---
+        if (enabled && config.EnableMetrics)
+        {
+            _meterProvider = Sdk.CreateMeterProviderBuilder()
+                .SetResourceBuilder(resourceBuilder)
+                .AddMeter(DeadworksMetrics.MeterName)
+                .AddOtlpExporter(configureOtlp)
+                .Build();
+        }
+
+        // --- Traces ---
+        if (enabled && config.EnableTraces)
+        {
+            var tracerBuilder = Sdk.CreateTracerProviderBuilder()
+                .SetResourceBuilder(resourceBuilder)
+                .AddSource(DeadworksTracing.SourceName)
+                .AddOtlpExporter(configureOtlp);
+
+            if (config.TraceSamplingRatio < 1.0)
+                tracerBuilder.SetSampler(new TraceIdRatioBasedSampler(config.TraceSamplingRatio));
+
+            _tracerProvider = tracerBuilder.Build();
+        }
+
+        var logger = CreateLogger("DeadworksTelemetry");
+        logger.LogInformation("Telemetry initialized (enabled={Enabled}, endpoint={Endpoint}, protocol={Protocol})",
+            enabled, otlpEndpoint, otlpProtocol);
+    }
+
+    public static ILogger CreateLogger(string categoryName)
+    {
+        return _loggerFactory?.CreateLogger(categoryName) ?? Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance.CreateLogger(categoryName);
+    }
+
+    public static ILogger CreateLogger<T>()
+    {
+        return _loggerFactory?.CreateLogger<T>() ?? Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance.CreateLogger<T>();
+    }
+
+    /// <summary>
+    /// Flush pending exports and dispose all providers. Called during server shutdown.
+    /// </summary>
+    public static void Shutdown()
+    {
+        var logger = CreateLogger("DeadworksTelemetry");
+        logger.LogInformation("Telemetry shutting down");
+
+        _tracerProvider?.Dispose();
+        _tracerProvider = null;
+
+        _meterProvider?.Dispose();
+        _meterProvider = null;
+
+        _loggerFactory?.Dispose();
+        _loggerFactory = null;
+    }
+
+    private static string GetEnvString(string key, string defaultValue)
+    {
+        var value = Environment.GetEnvironmentVariable(key);
+        return string.IsNullOrEmpty(value) ? defaultValue : value;
+    }
+
+    private static bool GetEnvBool(string key, bool defaultValue)
+    {
+        var value = Environment.GetEnvironmentVariable(key);
+        if (string.IsNullOrEmpty(value)) return defaultValue;
+        return value.Equals("true", StringComparison.OrdinalIgnoreCase) || value == "1";
+    }
+}

--- a/managed/Telemetry/DeadworksTracing.cs
+++ b/managed/Telemetry/DeadworksTracing.cs
@@ -1,0 +1,13 @@
+using System.Diagnostics;
+
+namespace DeadworksManaged.Telemetry;
+
+/// <summary>
+/// ActivitySource for Deadworks distributed tracing.
+/// Spans are created only for infrequent lifecycle events — never for per-frame hooks.
+/// </summary>
+internal static class DeadworksTracing
+{
+    public const string SourceName = "Deadworks.Server";
+    public static readonly ActivitySource Source = new(SourceName, "1.0.0");
+}

--- a/managed/Telemetry/NativeEngineLoggerProvider.cs
+++ b/managed/Telemetry/NativeEngineLoggerProvider.cs
@@ -1,0 +1,72 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace DeadworksManaged.Telemetry;
+
+/// <summary>
+/// Logger provider that writes formatted log messages to the native engine console
+/// via the unmanaged callback pointer stored in <see cref="NativeLogCallback"/>.
+/// </summary>
+internal sealed unsafe class NativeEngineLoggerProvider : ILoggerProvider
+{
+    private readonly delegate* unmanaged[Cdecl]<char*, void> _callback;
+    private readonly ConcurrentDictionary<string, NativeEngineLogger> _loggers = new();
+
+    public NativeEngineLoggerProvider(delegate* unmanaged[Cdecl]<char*, void> callback, LogLevel minLevel)
+    {
+        _callback = callback;
+    }
+
+    public ILogger CreateLogger(string categoryName)
+    {
+        return _loggers.GetOrAdd(categoryName, name => new NativeEngineLogger(name, _callback));
+    }
+
+    public void Dispose()
+    {
+        _loggers.Clear();
+    }
+}
+
+internal sealed unsafe class NativeEngineLogger : ILogger
+{
+    private readonly string _category;
+    private readonly delegate* unmanaged[Cdecl]<char*, void> _callback;
+
+    public NativeEngineLogger(string category, delegate* unmanaged[Cdecl]<char*, void> callback)
+    {
+        _category = category;
+        _callback = callback;
+    }
+
+    public bool IsEnabled(LogLevel logLevel) => _callback != null;
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        if (!IsEnabled(logLevel))
+            return;
+
+        var message = formatter(state, exception);
+        var prefix = logLevel switch
+        {
+            LogLevel.Trace => "trce",
+            LogLevel.Debug => "dbug",
+            LogLevel.Information => "info",
+            LogLevel.Warning => "warn",
+            LogLevel.Error => "fail",
+            LogLevel.Critical => "crit",
+            _ => "????"
+        };
+
+        var formatted = $"[{_category}] {prefix}: {message}";
+        if (exception != null)
+            formatted = $"{formatted}\n{exception}";
+
+        fixed (char* ptr = formatted)
+        {
+            _callback(ptr);
+        }
+    }
+}

--- a/managed/Telemetry/NativeLogCallback.cs
+++ b/managed/Telemetry/NativeLogCallback.cs
@@ -1,0 +1,17 @@
+namespace DeadworksManaged.Telemetry;
+
+/// <summary>
+/// Static holder for the native engine log callback pointer.
+/// Set once from <see cref="EntryPoint.Initialize"/> and read by <see cref="NativeEngineLoggerProvider"/>.
+/// </summary>
+internal static unsafe class NativeLogCallback
+{
+    private static delegate* unmanaged[Cdecl]<char*, void> _callback;
+
+    public static delegate* unmanaged[Cdecl]<char*, void> Callback => _callback;
+
+    public static void Set(delegate* unmanaged[Cdecl]<char*, void> callback)
+    {
+        _callback = callback;
+    }
+}

--- a/managed/Telemetry/PluginLoggerRegistry.cs
+++ b/managed/Telemetry/PluginLoggerRegistry.cs
@@ -1,0 +1,45 @@
+using System.Collections.Concurrent;
+using DeadworksManaged.Api;
+using Microsoft.Extensions.Logging;
+
+namespace DeadworksManaged.Telemetry;
+
+/// <summary>
+/// Static registry mapping plugin instances to their ILogger.
+/// Mirrors <see cref="TimerRegistry"/> pattern exactly.
+/// </summary>
+internal static class PluginLoggerRegistry
+{
+    private static readonly ConcurrentDictionary<IDeadworksPlugin, ILogger> _loggers = new();
+
+    public static void Initialize()
+    {
+        LogResolver.Resolve = Get;
+    }
+
+    public static void Register(IDeadworksPlugin plugin)
+    {
+        var logger = DeadworksTelemetry.CreateLogger($"Plugin.{plugin.Name}");
+        _loggers[plugin] = logger;
+    }
+
+    public static void Unregister(IDeadworksPlugin plugin)
+    {
+        _loggers.TryRemove(plugin, out _);
+    }
+
+    public static ILogger Get(IDeadworksPlugin plugin)
+    {
+        if (_loggers.TryGetValue(plugin, out var logger))
+            return logger;
+
+        throw new InvalidOperationException(
+            $"No logger registered for plugin '{plugin.Name}'. " +
+            "Logger is only available after OnLoad and before OnUnload.");
+    }
+
+    public static void Clear()
+    {
+        _loggers.Clear();
+    }
+}

--- a/managed/TimerEngine.cs
+++ b/managed/TimerEngine.cs
@@ -1,6 +1,8 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using Microsoft.Extensions.Logging;
 using DeadworksManaged.Api;
+using DeadworksManaged.Telemetry;
 
 namespace DeadworksManaged;
 
@@ -10,6 +12,9 @@ namespace DeadworksManaged;
 /// </summary>
 internal static class TimerEngine
 {
+    private static ILogger? _logger;
+    private static ILogger Logger => _logger ??= DeadworksTelemetry.CreateLogger("TimerEngine");
+
     private static long _currentTick;
     private static long _currentMs;
     private static readonly Stopwatch _stopwatch = new();
@@ -51,7 +56,8 @@ internal static class TimerEngine
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"[TimerEngine] NextTick callback threw: {ex.Message}");
+                Logger.LogError(ex, "NextTick callback threw");
+                DeadworksMetrics.TimerErrors.Add(1);
             }
             nextTickCount++;
         }
@@ -87,6 +93,9 @@ internal static class TimerEngine
             taskCount++;
             ExecuteTask(task);
         }
+
+        if (taskCount > 0)
+            DeadworksMetrics.TimerTasksPerFrame.Record(taskCount);
     }
 
     private static void ExecuteTask(ScheduledTask task)
@@ -103,7 +112,8 @@ internal static class TimerEngine
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"[TimerEngine] Timer callback threw: {ex.Message}");
+            Logger.LogError(ex, "Timer callback threw");
+            DeadworksMetrics.TimerErrors.Add(1);
         }
 
         if (task.Repeating && !task.Cancelled)
@@ -128,7 +138,8 @@ internal static class TimerEngine
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"[TimerEngine] Sequence callback threw: {ex.Message}");
+            Logger.LogError(ex, "Sequence callback threw");
+            DeadworksMetrics.TimerErrors.Add(1);
             FinishTask(task);
             return;
         }


### PR DESCRIPTION
## Summary

- Adds production-grade observability via Microsoft.Extensions.Logging + OpenTelemetry OTLP
- Dual-sink logging: `NativeEngineLoggerProvider` (game console) + OTLP log exporter
- Plugins get `ILogger` via `LogResolver`/`PluginLoggerRegistry` with zero setup — just use `Logger.LogInformation(...)` from any plugin
- 19 metric instruments on `Meter("Deadworks.Server")` covering plugin lifecycle, player connections, frame performance, timer engine, heartbeat, event dispatch, chat, and commands
- `ActivitySource` traces on lifecycle operations (plugin load/unload, client connect/disconnect, server startup, heartbeat, command dispatch)
- All telemetry config via `DEADWORKS_*` environment variables — OTLP export is **disabled by default**, enable with `DEADWORKS_TELEMETRY_ENABLED=true`
- Migrates all `Console.WriteLine` calls to structured `ILogger` calls across the entire codebase

## Environment Variables

| Variable | Default | Description |
|---|---|---|
| `DEADWORKS_TELEMETRY_ENABLED` | `false` | Enable OTLP export |
| `DEADWORKS_OTLP_ENDPOINT` | `http://localhost:4317` | OTLP collector endpoint |
| `DEADWORKS_OTLP_PROTOCOL` | `grpc` | `grpc` or `http/protobuf` |
| `DEADWORKS_SERVICE_NAME` | `deadworks-server` | OTel service name |
| `DEADWORKS_LOG_LEVEL` | `Information` | Minimum log level |