### PR TITLE
Add file logging, crash on .NET init errors

### DIFF
--- a/deadworks/src/Core/Deadworks.cpp
+++ b/deadworks/src/Core/Deadworks.cpp
@@ -76,8 +76,9 @@ void Deadworks::InitFromAppSystem(CAppSystemDict *pAppSystem) {
     Module server("../../citadel/bin/win64/server.dll");
     GetInterfaceFactories();
 
-    g_Log = std::make_unique<S2Logger>("deadworks");
-    g_Log->Info("Log Startup");
+    auto logPath = std::filesystem::current_path() / "deadworks.log";
+    g_Log = std::make_unique<TeeLogger>(std::make_unique<S2Logger>("deadworks"), logPath, g_FileLogLevel);
+    g_Log->Info("Log Startup (log level: {})", GetVerbosityName(g_FileLogLevel));
     g_Log->Info("InitFromAppSystem");
 
     hooks::g_ServerCreateInterface = safetyhook::create_inline(InterfaceFactories.server, hooks::Hook_ServerCreateInterface);

--- a/deadworks/src/Core/Deadworks.hpp
+++ b/deadworks/src/Core/Deadworks.hpp
@@ -3,6 +3,8 @@
 #include <iappsystem.h>
 
 #include "../Logging/S2Logger.hpp"
+#include "../Logging/TeeLogger.hpp"
+#include "../Logging/LogOptions.hpp"
 #include "../Lib/Module.hpp"
 #include "../Hosting/DotNetHost.hpp"
 

--- a/deadworks/src/Core/ManagedCallbacks.cpp
+++ b/deadworks/src/Core/ManagedCallbacks.cpp
@@ -3,7 +3,24 @@
 #include "Deadworks.hpp"
 #include "../Hosting/DotNetHost.hpp"
 
+#include <cstdlib>
+
 using namespace deadworks;
+
+[[noreturn]] static void FatalDotNetInitFailure(const std::filesystem::path &runtimeConfig, const DotNetInitError &err) {
+    g_Log->Critical(
+        "Failed to initialize .NET scripting runtime. "
+        "stage={} rc={} (0x{:08X}) runtimeConfig={}. "
+        "This almost always means the required .NET runtime version is not installed, "
+        "or does not match the TargetFramework in the runtime config. "
+        "Install the matching .NET runtime and try again.",
+        err.StageName(),
+        err.rc,
+        static_cast<unsigned int>(err.rc),
+        runtimeConfig.string());
+
+    std::_Exit(1);
+}
 
 // ConCommand dispatch fn pointer defined in NativeCallbacks.cpp
 using ManagedConCommandDispatchFn = void(CORECLR_DELEGATE_CALLTYPE *)(int playerSlot, const char *command, int argc, const char **argv);
@@ -28,8 +45,8 @@ void deadworks::InitializeManagedCallbacks(DotNetHost &host, ManagedCallbacks &m
     auto assemblyPath = managedDir / "DeadworksManaged.dll";
 
     if (!host.Initialize(runtimeConfig)) {
-        g_Log->Error("Failed to initialize .NET runtime");
-        return;
+        auto err = host.LastError().value_or(DotNetInitError{});
+        FatalDotNetInitFailure(runtimeConfig, err);
     }
 
     g_Log->Info(".NET runtime initialized");
@@ -39,8 +56,7 @@ void deadworks::InitializeManagedCallbacks(DotNetHost &host, ManagedCallbacks &m
         assemblyPath, kManagedTypeName, L"Initialize");
 
     if (!initialize) {
-        g_Log->Error("Failed to get managed EntryPoint.Initialize");
-        return;
+        FatalDotNetInitFailure(runtimeConfig, DotNetInitError{DotNetInitError::Stage::LoadManagedEntryPoint, 0});
     }
 
     NativeCallbacks callbacks{};

--- a/deadworks/src/Core/ManagedCallbacks.cpp
+++ b/deadworks/src/Core/ManagedCallbacks.cpp
@@ -22,6 +22,62 @@ using namespace deadworks;
     std::_Exit(1);
 }
 
+namespace {
+
+// CLR surfaces unhandled managed exceptions to native [UnmanagedCallersOnly] callers
+// as SEH with this exception code. ExceptionInformation[0] holds the HResult.
+constexpr DWORD kClrExceptionCode = 0xE0434352;
+
+struct ManagedInvokeFailure {
+    DWORD exceptionCode = 0;
+    ULONG_PTR hresult = 0;
+};
+
+DWORD CaptureManagedException(EXCEPTION_POINTERS *ep, ManagedInvokeFailure *out) {
+    out->exceptionCode = ep->ExceptionRecord->ExceptionCode;
+    if (ep->ExceptionRecord->NumberParameters > 0)
+        out->hresult = ep->ExceptionRecord->ExceptionInformation[0];
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+
+using ManagedInitializeFn = void(CORECLR_DELEGATE_CALLTYPE *)(NativeCallbacks *);
+
+// Isolated from callers with C++ objects because __try/__except forbids
+// destructor unwinding through the guarded region.
+bool InvokeManagedInitialize(ManagedInitializeFn fn, NativeCallbacks *callbacks,
+                             ManagedInvokeFailure &failure) {
+    __try {
+        fn(callbacks);
+        return true;
+    } __except (CaptureManagedException(GetExceptionInformation(), &failure)) {
+        return false;
+    }
+}
+
+} // namespace
+
+[[noreturn]] static void FatalManagedInvokeFailure(const std::filesystem::path &managedDir,
+                                                   const ManagedInvokeFailure &failure) {
+    if (failure.exceptionCode == kClrExceptionCode) {
+        g_Log->Critical(
+            "Managed EntryPoint.Initialize threw an unhandled exception "
+            "(HResult=0x{:08X}). This almost always means DeadworksManaged.dll "
+            "could not load one of its dependencies. Verify every DLL listed in "
+            "DeadworksManaged.deps.json (e.g. Google.Protobuf.dll) is present "
+            "alongside DeadworksManaged.dll in {}.",
+            static_cast<unsigned int>(failure.hresult),
+            managedDir.string());
+    } else {
+        g_Log->Critical(
+            "Managed EntryPoint.Initialize crashed with native exception code "
+            "0x{:08X} (param0=0x{:016X}).",
+            static_cast<unsigned int>(failure.exceptionCode),
+            static_cast<uint64_t>(failure.hresult));
+    }
+
+    std::_Exit(1);
+}
+
 // ConCommand dispatch fn pointer defined in NativeCallbacks.cpp
 using ManagedConCommandDispatchFn = void(CORECLR_DELEGATE_CALLTYPE *)(int playerSlot, const char *command, int argc, const char **argv);
 extern ManagedConCommandDispatchFn g_ManagedConCommandDispatch;
@@ -61,7 +117,12 @@ void deadworks::InitializeManagedCallbacks(DotNetHost &host, ManagedCallbacks &m
 
     NativeCallbacks callbacks{};
     PopulateNativeCallbacks(callbacks);
-    initialize(&callbacks);
+
+    ManagedInvokeFailure failure{};
+    if (!InvokeManagedInitialize(initialize, &callbacks, failure)) {
+        FatalManagedInvokeFailure(managedDir, failure);
+    }
+
     g_Log->Info(".NET managed code invoked successfully");
 
     BindCallback(host, assemblyPath, managed.onStartupServer, L"OnStartupServer");

--- a/deadworks/src/Hosting/DotNetHost.cpp
+++ b/deadworks/src/Hosting/DotNetHost.cpp
@@ -6,16 +6,33 @@
 
 namespace deadworks {
 
+std::string_view DotNetInitError::StageName() const {
+    switch (stage) {
+    case Stage::HostFxrPathLookup: return "get_hostfxr_path";
+    case Stage::HostFxrLoadLibrary: return "LoadLibrary(hostfxr.dll)";
+    case Stage::HostFxrSymbolLookup: return "GetProcAddress(hostfxr symbols)";
+    case Stage::InitForRuntimeConfig: return "hostfxr_initialize_for_runtime_config";
+    case Stage::GetRuntimeDelegate: return "hostfxr_get_runtime_delegate";
+    case Stage::LoadManagedEntryPoint: return "load DeadworksManaged.EntryPoint.Initialize";
+    }
+    return "unknown";
+}
+
 bool DotNetHost::LoadHostFxr() {
     wchar_t buffer[MAX_PATH];
     size_t bufferSize = sizeof(buffer) / sizeof(wchar_t);
 
-    if (get_hostfxr_path(buffer, &bufferSize, nullptr) != 0)
+    int rc = get_hostfxr_path(buffer, &bufferSize, nullptr);
+    if (rc != 0) {
+        m_lastError = DotNetInitError{DotNetInitError::Stage::HostFxrPathLookup, rc};
         return false;
+    }
 
     m_hostfxrLib = LoadLibraryW(buffer);
-    if (!m_hostfxrLib)
+    if (!m_hostfxrLib) {
+        m_lastError = DotNetInitError{DotNetInitError::Stage::HostFxrLoadLibrary, static_cast<int>(GetLastError())};
         return false;
+    }
 
     m_initForConfig = reinterpret_cast<hostfxr_initialize_for_runtime_config_fn>(
         GetProcAddress(m_hostfxrLib, "hostfxr_initialize_for_runtime_config"));
@@ -24,13 +41,19 @@ bool DotNetHost::LoadHostFxr() {
     m_close = reinterpret_cast<hostfxr_close_fn>(
         GetProcAddress(m_hostfxrLib, "hostfxr_close"));
 
-    return m_initForConfig && m_getRuntimeDelegate && m_close;
+    if (!(m_initForConfig && m_getRuntimeDelegate && m_close)) {
+        m_lastError = DotNetInitError{DotNetInitError::Stage::HostFxrSymbolLookup, 0};
+        return false;
+    }
+    return true;
 }
 
 bool DotNetHost::InitializeRuntime(const std::filesystem::path &runtimeConfigPath) {
     int rc = m_initForConfig(runtimeConfigPath.c_str(), nullptr, &m_hostContext);
-    if (rc != 0 || !m_hostContext)
+    if (rc != 0 || !m_hostContext) {
+        m_lastError = DotNetInitError{DotNetInitError::Stage::InitForRuntimeConfig, rc};
         return false;
+    }
 
     void *delegate = nullptr;
     rc = m_getRuntimeDelegate(
@@ -38,8 +61,10 @@ bool DotNetHost::InitializeRuntime(const std::filesystem::path &runtimeConfigPat
         hdt_load_assembly_and_get_function_pointer,
         &delegate);
 
-    if (rc != 0 || !delegate)
+    if (rc != 0 || !delegate) {
+        m_lastError = DotNetInitError{DotNetInitError::Stage::GetRuntimeDelegate, rc};
         return false;
+    }
 
     m_loadAssemblyAndGetFunctionPointer =
         reinterpret_cast<load_assembly_and_get_function_pointer_fn>(delegate);
@@ -48,6 +73,8 @@ bool DotNetHost::InitializeRuntime(const std::filesystem::path &runtimeConfigPat
 }
 
 bool DotNetHost::Initialize(const std::filesystem::path &runtimeConfigPath) {
+    m_lastError.reset();
+
     if (!LoadHostFxr())
         return false;
 

--- a/deadworks/src/Hosting/DotNetHost.hpp
+++ b/deadworks/src/Hosting/DotNetHost.hpp
@@ -11,10 +11,27 @@
 
 namespace deadworks {
 
+struct DotNetInitError {
+    enum class Stage {
+        HostFxrPathLookup,
+        HostFxrLoadLibrary,
+        HostFxrSymbolLookup,
+        InitForRuntimeConfig,
+        GetRuntimeDelegate,
+        LoadManagedEntryPoint,
+    };
+    Stage stage{};
+    int rc = 0;
+
+    std::string_view StageName() const;
+};
+
 class DotNetHost {
 public:
     bool Initialize(const std::filesystem::path &runtimeConfigPath);
     void Close();
+
+    const std::optional<DotNetInitError> &LastError() const { return m_lastError; }
 
     // Load an assembly and get a function pointer to a static method marked [UnmanagedCallersOnly]
     template <typename TFunc>
@@ -51,6 +68,8 @@ private:
     hostfxr_close_fn m_close = nullptr;
 
     load_assembly_and_get_function_pointer_fn m_loadAssemblyAndGetFunctionPointer = nullptr;
+
+    std::optional<DotNetInitError> m_lastError;
 };
 
 } // namespace deadworks

--- a/deadworks/src/Logging/LogOptions.hpp
+++ b/deadworks/src/Logging/LogOptions.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "Logger.hpp"
+
+namespace deadworks {
+
+inline LoggingVerbosity g_FileLogLevel = LoggingVerbosity::Info;
+
+} // namespace deadworks

--- a/deadworks/src/Logging/Logger.hpp
+++ b/deadworks/src/Logging/Logger.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <optional>
+#include <string>
 #include <string_view>
 #include <format>
 
@@ -30,6 +32,20 @@ inline std::string_view GetVerbosityName(LoggingVerbosity verbosity) {
         return "CRT";
     }
     return "???";
+}
+
+inline std::optional<LoggingVerbosity> ParseVerbosity(std::string_view s) {
+    std::string lower;
+    lower.reserve(s.size());
+    for (char c : s) lower.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+
+    if (lower == "verbose") return LoggingVerbosity::Verbose;
+    if (lower == "debug") return LoggingVerbosity::Debug;
+    if (lower == "info") return LoggingVerbosity::Info;
+    if (lower == "warning") return LoggingVerbosity::Warning;
+    if (lower == "error") return LoggingVerbosity::Error;
+    if (lower == "critical") return LoggingVerbosity::Critical;
+    return std::nullopt;
 }
 
 class Logger {

--- a/deadworks/src/Logging/TeeLogger.hpp
+++ b/deadworks/src/Logging/TeeLogger.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <mutex>
+#include <string>
+
+#include "Logger.hpp"
+#include "../Utils/Chrono.hpp"
+
+namespace deadworks {
+
+class TeeLogger : public Logger {
+public:
+    TeeLogger(std::unique_ptr<Logger> inner,
+              const std::filesystem::path &filePath,
+              LoggingVerbosity fileMinVerbosity = LoggingVerbosity::Info)
+        : m_inner(std::move(inner)), m_fileMin(fileMinVerbosity) {
+        m_file.open(filePath, std::ios::out | std::ios::app);
+    }
+
+    void Log(LoggingVerbosity verbosity, std::string_view message) override {
+        if (m_inner) m_inner->Log(verbosity, message);
+
+        if (verbosity < m_fileMin) return;
+
+        std::lock_guard<std::mutex> lock(m_fileMutex);
+        if (!m_file.is_open()) return;
+
+        const auto ts = utils::FormattedNow();
+        m_file << '[' << ts << "] [" << GetVerbosityName(verbosity) << "] " << message << '\n';
+        m_file.flush();
+    }
+
+private:
+    std::unique_ptr<Logger> m_inner;
+    LoggingVerbosity m_fileMin;
+    std::ofstream m_file;
+    std::mutex m_fileMutex;
+};
+
+} // namespace deadworks

--- a/deadworks/src/startup.cpp
+++ b/deadworks/src/startup.cpp
@@ -2,7 +2,10 @@
 #include "Memory/MemoryDataLoader.hpp"
 #include "Memory/Scanner.hpp"
 #include "Logging/ConsoleLogger.hpp"
+#include "Logging/LogOptions.hpp"
 #include "Core/Hooks/CoreHooks.hpp"
+
+#include <vector>
 
 using namespace std::literals;
 
@@ -62,11 +65,45 @@ int main(int argc, char **argv) {
 
     constexpr auto DEFAULT_CMD_LINE = "-dedicated -console -dev -insecure -allow_no_lobby_connect +tv_citadel_auto_record 0 +spec_replay_enable 0 +tv_enable 0 +citadel_upload_replay_enabled 0 +hostport 27015 +map dl_midtown"sv;
 
+    constexpr std::string_view kLogLevelFlag = "-dw_loglevel";
+
+    std::vector<std::string> passedArgs;
+    for (int i = 1; i < argc; i++) {
+        std::string_view arg = argv[i];
+
+        if (arg == kLogLevelFlag) {
+            if (i + 1 >= argc) {
+                log.Warning("{} requires a value (verbose|debug|info|warning|error|critical)", kLogLevelFlag);
+                continue;
+            }
+            if (auto v = deadworks::ParseVerbosity(argv[i + 1])) {
+                deadworks::g_FileLogLevel = *v;
+                log.Info("Log level set to {}", argv[i + 1]);
+            } else {
+                log.Warning("Unknown log level '{}', keeping default", argv[i + 1]);
+            }
+            ++i;
+            continue;
+        }
+        if (arg.starts_with(std::string(kLogLevelFlag) + "=")) {
+            auto value = arg.substr(kLogLevelFlag.size() + 1);
+            if (auto v = deadworks::ParseVerbosity(value)) {
+                deadworks::g_FileLogLevel = *v;
+                log.Info("Log level set to {}", value);
+            } else {
+                log.Warning("Unknown log level '{}', keeping default", value);
+            }
+            continue;
+        }
+
+        passedArgs.emplace_back(arg);
+    }
+
     std::string cmdLine;
-    if (argc > 1) {
-        for (int i = 1; i < argc; i++) {
-            if (i > 1) cmdLine += ' ';
-            cmdLine += argv[i];
+    if (!passedArgs.empty()) {
+        for (size_t i = 0; i < passedArgs.size(); i++) {
+            if (i > 0) cmdLine += ' ';
+            cmdLine += passedArgs[i];
         }
     } else {
         cmdLine = DEFAULT_CMD_LINE;


### PR DESCRIPTION
Adds a log file to deadworks called deadworks.log 

Some questions for @perrccyy 

1. Added a param to starup called dw_loglevel which indicates what log level should be written to this log file. What should the default be?

2. Should we add a param to disable the log file?

3. Do we need to worry about pruning the file at a certain size?

4. Should we call the file deadworks.txt so its easier for people to inspect it in notepad?