### PR TITLE
Add customizable launcher backgrounds

### DIFF
--- a/launcher/src-tauri/Cargo.lock
+++ b/launcher/src-tauri/Cargo.lock
@@ -743,6 +743,7 @@ dependencies = [
 name = "deadworks-launcher"
 version = "0.3.3"
 dependencies = [
+ "base64 0.22.1",
  "bzip2",
  "futures-util",
  "open",

--- a/launcher/src-tauri/Cargo.toml
+++ b/launcher/src-tauri/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { version = "1", features = ["fs", "io-util"] }
 futures-util = "0.3"
 bzip2 = "0.5"
 uuid = { version = "1", features = ["v4"] }
+base64 = "0.22"
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.55"

--- a/launcher/src-tauri/src/backgrounds.rs
+++ b/launcher/src-tauri/src/backgrounds.rs
@@ -1,0 +1,46 @@
+use base64::Engine;
+
+const MAX_BACKGROUND_BYTES: u64 = 25 * 1024 * 1024;
+
+fn image_mime_type(path: &str) -> Result<&'static str, String> {
+    let ext = std::path::Path::new(path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|ext| ext.to_ascii_lowercase())
+        .unwrap_or_default();
+
+    match ext.as_str() {
+        "png" => Ok("image/png"),
+        "jpg" | "jpeg" => Ok("image/jpeg"),
+        "webp" => Ok("image/webp"),
+        "gif" => Ok("image/gif"),
+        _ => Err("Background must be a PNG, JPG, WebP, or GIF image".into()),
+    }
+}
+
+#[tauri::command]
+pub fn validate_launcher_background(path: String) -> Result<(), String> {
+    image_mime_type(&path)?;
+    let metadata = std::fs::metadata(&path)
+        .map_err(|e| format!("Failed to read background image metadata: {}", e))?;
+    if !metadata.is_file() {
+        return Err("Background path must point to a file".into());
+    }
+    if metadata.len() > MAX_BACKGROUND_BYTES {
+        return Err(format!(
+            "Background image is too large ({} bytes, max {} bytes)",
+            metadata.len(), MAX_BACKGROUND_BYTES
+        ));
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub fn get_launcher_background_data_url(path: String) -> Result<String, String> {
+    validate_launcher_background(path.clone())?;
+    let mime_type = image_mime_type(&path)?;
+    let bytes = std::fs::read(&path)
+        .map_err(|e| format!("Failed to read background image: {}", e))?;
+    let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+    Ok(format!("data:{};base64,{}", mime_type, encoded))
+}

--- a/launcher/src-tauri/src/lib.rs
+++ b/launcher/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod addons;
+mod backgrounds;
 mod connect;
 mod deep_link;
 mod gameinfo;
@@ -55,6 +56,8 @@ pub fn run() {
             connect::set_game_dir,
             connect::reset_game_dir,
             addons::prepare_and_connect,
+            backgrounds::validate_launcher_background,
+            backgrounds::get_launcher_background_data_url,
             ping::ping_server,
             deep_link::deep_link_ready,
         ])

--- a/launcher/src/App.module.css
+++ b/launcher/src/App.module.css
@@ -1,8 +1,25 @@
+.background {
+  position: fixed;
+  inset: 0;
+  background: linear-gradient(135deg, #141414 0%, #000000 100%);
+  background-position: center;
+  background-size: cover;
+  pointer-events: none;
+}
+
+.background::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 50% 10%, rgba(105, 232, 153, 0.08), transparent 42%);
+}
+
 .main {
   position: fixed;
   top: calc(var(--titlebar-height) - 12px);
   left: 0;
   right: 0;
   bottom: 0;
+  z-index: 1;
   overflow-y: auto;
 }

--- a/launcher/src/App.tsx
+++ b/launcher/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState, type CSSProperties } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import Titlebar from "@/components/Titlebar";
 import ServersPage from "@/components/ServersPage";
@@ -13,6 +13,14 @@ import styles from "./App.module.css";
 export default function App() {
   const settings = useSettings();
   const { request, clear } = useDeepLink(settings.apiUrl);
+  const [backgroundDataUrl, setBackgroundDataUrl] = useState<string | null>(null);
+  const backgroundStyle = backgroundDataUrl
+    ? ({
+        backgroundImage: `linear-gradient(135deg, rgba(20, 20, 20, 0.22) 0%, rgba(0, 0, 0, 0.38) 100%), url("${backgroundDataUrl}")`,
+        backgroundPosition: `center, ${settings.launcherBackgroundPositionX}% ${settings.launcherBackgroundPositionY}%`,
+        backgroundSize: `cover, ${settings.launcherBackgroundZoom}%`,
+      } satisfies CSSProperties)
+    : undefined;
 
   // On first launch, enable autostart by default
   useEffect(() => {
@@ -26,8 +34,32 @@ export default function App() {
     });
   }, []);
 
+  useEffect(() => {
+    if (!settings.launcherBackgroundPath) {
+      setBackgroundDataUrl(null);
+      return;
+    }
+
+    let cancelled = false;
+    invoke<string>("get_launcher_background_data_url", {
+      path: settings.launcherBackgroundPath,
+    })
+      .then((dataUrl) => {
+        if (!cancelled) setBackgroundDataUrl(dataUrl);
+      })
+      .catch((error) => {
+        console.error("Failed to load launcher background:", error);
+        if (!cancelled) setBackgroundDataUrl(null);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [settings.launcherBackgroundPath]);
+
   return (
     <>
+      <div className={styles.background} style={backgroundStyle} aria-hidden="true" />
       <Titlebar />
       <main className={styles.main}>
         <ServersPage apiUrl={settings.apiUrl} />

--- a/launcher/src/components/ServerTable.module.css
+++ b/launcher/src/components/ServerTable.module.css
@@ -22,7 +22,7 @@
 
 .table th {
   position: relative;
-  background: #161720;
+  background: rgba(22, 23, 32, 0.70);
   padding: 8px 12px;
   font-size: 0.7rem;
   font-weight: 700;

--- a/launcher/src/components/ServersPage.module.css
+++ b/launcher/src/components/ServersPage.module.css
@@ -51,7 +51,7 @@
 .tabActive {
   color: var(--text);
   font-weight: 800;
-  background: #151620;
+  background: rgba(21, 22, 32, 0.62);
   border-color: var(--border);
 }
 
@@ -71,7 +71,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  background: var(--bg-card);
+  background: rgba(15, 16, 22, 0.66);
   border: 1px solid var(--border);
   border-radius: 2px;
   padding: 10px 12px;
@@ -108,7 +108,7 @@
   justify-content: center;
   width: 40px;
   height: 40px;
-  background: var(--bg-card);
+  background: rgba(15, 16, 22, 0.66);
   border: 1px solid var(--border);
   border-radius: 2px;
   color: var(--text-muted);
@@ -168,7 +168,7 @@
   letter-spacing: 1.5px;
   text-transform: uppercase;
   color: var(--text);
-  background: var(--bg-card);
+  background: rgba(15, 16, 22, 0.66);
   border: 1px solid var(--border);
   border-radius: 2px;
   cursor: pointer;
@@ -215,7 +215,8 @@
   min-height: 0;
   display: flex;
   flex-direction: column;
-  background: var(--bg-panel);
+  background: rgba(11, 12, 16, 0.56);
   border: 1px solid var(--border);
   overflow: hidden;
+  backdrop-filter: blur(2px);
 }

--- a/launcher/src/components/SettingsWindow.module.css
+++ b/launcher/src/components/SettingsWindow.module.css
@@ -228,6 +228,57 @@
   color: var(--accent);
 }
 
+.devBtn:disabled {
+  color: var(--disabled-text);
+  cursor: default;
+  border-color: var(--border);
+}
+
+.inlineError {
+  margin-top: -6px;
+  margin-bottom: 8px;
+  font-size: 0.75rem;
+  color: var(--ping-bad);
+}
+
+.backgroundLayoutControls {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px 16px;
+  align-items: end;
+  padding: 12px 0 4px;
+  border-bottom: 1px solid var(--separator);
+}
+
+.sliderRow {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.sliderLabel {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.76rem;
+  color: var(--text-muted);
+}
+
+.sliderLabel span {
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
+}
+
+.slider {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+.backgroundLayoutControls .devBtn {
+  grid-row: 1 / span 3;
+  grid-column: 2;
+  align-self: center;
+}
+
 /* Toggle switch */
 .toggle {
   position: relative;

--- a/launcher/src/components/SettingsWindow.tsx
+++ b/launcher/src/components/SettingsWindow.tsx
@@ -34,13 +34,28 @@ function SettingRow({
 }
 
 export default function SettingsWindow() {
-  const { apiEndpoint, setApiEndpoint, telemetryEnabled, setTelemetryEnabled } = useSettings();
+  const {
+    apiEndpoint,
+    setApiEndpoint,
+    telemetryEnabled,
+    setTelemetryEnabled,
+    launcherBackgroundPath,
+    setLauncherBackgroundPath,
+    launcherBackgroundZoom,
+    setLauncherBackgroundZoom,
+    launcherBackgroundPositionX,
+    setLauncherBackgroundPositionX,
+    launcherBackgroundPositionY,
+    setLauncherBackgroundPositionY,
+    resetLauncherBackgroundLayout,
+  } = useSettings();
   const [activeSection, setActiveSection] = useState("general");
   const [autostart, setAutostart] = useState(false);
   const [detectedPath, setDetectedPath] = useState<string | null>(null);
   const [currentPath, setCurrentPath] = useState<string | null>(null);
   const [isOverridden, setIsOverridden] = useState(false);
   const [gameDirError, setGameDirError] = useState<string | null>(null);
+  const [backgroundError, setBackgroundError] = useState<string | null>(null);
   const win = getCurrentWindow();
 
   useEffect(() => {
@@ -90,6 +105,24 @@ export default function SettingsWindow() {
     setCurrentPath(detectedPath);
     setIsOverridden(false);
     setGameDirError(null);
+  };
+
+  const handleBrowseBackground = async () => {
+    const selected = await open({
+      title: "Select launcher background image",
+      filters: [
+        { name: "Images", extensions: ["png", "jpg", "jpeg", "webp", "gif"] },
+      ],
+    });
+    const path = Array.isArray(selected) ? selected[0] : selected;
+    if (!path) return;
+    try {
+      await invoke("validate_launcher_background", { path });
+      await setLauncherBackgroundPath(path);
+      setBackgroundError(null);
+    } catch (e) {
+      setBackgroundError(typeof e === "string" ? e : String(e));
+    }
   };
 
   const toggleAutostart = async (enabled: boolean) => {
@@ -172,6 +205,86 @@ export default function SettingsWindow() {
                   </button>
                 }
               />
+
+              <div className={styles.sectionSubtitle}>Appearance</div>
+
+              <div className={styles.settingRow}>
+                <div className={styles.settingInfo}>
+                  <div className={styles.settingLabel}>Launcher Background</div>
+                  <div className={styles.settingDesc}>
+                    Choose a local image to display behind the launcher
+                  </div>
+                  <div className={styles.pathDisplay}>
+                    {launcherBackgroundPath || "Default gradient"}
+                  </div>
+                </div>
+                <div className={styles.pathButtons}>
+                  <button className={styles.devBtn} onClick={handleBrowseBackground}>
+                    Browse
+                  </button>
+                  {launcherBackgroundPath && (
+                    <button className={styles.devBtn} onClick={() => setLauncherBackgroundPath(null)}>
+                      Reset
+                    </button>
+                  )}
+                </div>
+              </div>
+              {backgroundError && (
+                <div className={styles.inlineError}>{backgroundError}</div>
+              )}
+
+              {launcherBackgroundPath && (
+                <div className={styles.backgroundLayoutControls}>
+                  <div className={styles.sliderRow}>
+                    <label className={styles.sliderLabel} htmlFor="background-zoom">
+                      Zoom <span>{launcherBackgroundZoom}%</span>
+                    </label>
+                    <input
+                      id="background-zoom"
+                      className={styles.slider}
+                      type="range"
+                      min="100"
+                      max="250"
+                      step="1"
+                      value={launcherBackgroundZoom}
+                      onChange={(e) => setLauncherBackgroundZoom(Number(e.target.value))}
+                    />
+                  </div>
+                  <div className={styles.sliderRow}>
+                    <label className={styles.sliderLabel} htmlFor="background-position-x">
+                      Horizontal <span>{launcherBackgroundPositionX}%</span>
+                    </label>
+                    <input
+                      id="background-position-x"
+                      className={styles.slider}
+                      type="range"
+                      min="0"
+                      max="100"
+                      step="1"
+                      value={launcherBackgroundPositionX}
+                      onChange={(e) => setLauncherBackgroundPositionX(Number(e.target.value))}
+                    />
+                  </div>
+                  <div className={styles.sliderRow}>
+                    <label className={styles.sliderLabel} htmlFor="background-position-y">
+                      Vertical <span>{launcherBackgroundPositionY}%</span>
+                    </label>
+                    <input
+                      id="background-position-y"
+                      className={styles.slider}
+                      type="range"
+                      min="0"
+                      max="100"
+                      step="1"
+                      value={launcherBackgroundPositionY}
+                      onChange={(e) => setLauncherBackgroundPositionY(Number(e.target.value))}
+                    />
+                  </div>
+                  <button className={styles.devBtn} onClick={resetLauncherBackgroundLayout}>
+                    Reset Position
+                  </button>
+                </div>
+              )}
 
               <div className={styles.sectionSubtitle}>Game Location</div>
 

--- a/launcher/src/hooks/use-settings.ts
+++ b/launcher/src/hooks/use-settings.ts
@@ -5,20 +5,44 @@ import { getStore, getApiUrl } from "@/lib/tauri";
 
 export interface Settings {
   apiEndpoint: string;
-  setApiEndpoint: (endpoint: string) => void;
+  setApiEndpoint: (endpoint: string) => Promise<void>;
   apiUrl: string;
   telemetryEnabled: boolean;
-  setTelemetryEnabled: (enabled: boolean) => void;
+  setTelemetryEnabled: (enabled: boolean) => Promise<void>;
+  launcherBackgroundPath: string | null;
+  setLauncherBackgroundPath: (path: string | null) => Promise<void>;
+  launcherBackgroundZoom: number;
+  setLauncherBackgroundZoom: (zoom: number) => Promise<void>;
+  launcherBackgroundPositionX: number;
+  setLauncherBackgroundPositionX: (position: number) => Promise<void>;
+  launcherBackgroundPositionY: number;
+  setLauncherBackgroundPositionY: (position: number) => Promise<void>;
+  resetLauncherBackgroundLayout: () => Promise<void>;
 }
 
 interface SettingsPayload {
   apiEndpoint: string;
   telemetryEnabled: boolean;
+  launcherBackgroundPath: string | null;
+  launcherBackgroundZoom: number;
+  launcherBackgroundPositionX: number;
+  launcherBackgroundPositionY: number;
+}
+
+const DEFAULT_BACKGROUND_ZOOM = 100;
+const DEFAULT_BACKGROUND_POSITION = 50;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
 }
 
 export function useSettings(): Settings {
   const [apiEndpoint, setApiEndpointState] = useState("prod");
   const [telemetryEnabled, setTelemetryEnabledState] = useState(true);
+  const [launcherBackgroundPath, setLauncherBackgroundPathState] = useState<string | null>(null);
+  const [launcherBackgroundZoom, setLauncherBackgroundZoomState] = useState(DEFAULT_BACKGROUND_ZOOM);
+  const [launcherBackgroundPositionX, setLauncherBackgroundPositionXState] = useState(DEFAULT_BACKGROUND_POSITION);
+  const [launcherBackgroundPositionY, setLauncherBackgroundPositionYState] = useState(DEFAULT_BACKGROUND_POSITION);
 
   useEffect(() => {
     getStore().then(async (store) => {
@@ -28,6 +52,14 @@ export function useSettings(): Settings {
       if (telemetry !== undefined && telemetry !== null) {
         setTelemetryEnabledState(telemetry);
       }
+      const backgroundPath = await store.get<string>("launcher_background_path");
+      setLauncherBackgroundPathState(backgroundPath || null);
+      const backgroundZoom = await store.get<number>("launcher_background_zoom");
+      setLauncherBackgroundZoomState(clamp(backgroundZoom ?? DEFAULT_BACKGROUND_ZOOM, 100, 250));
+      const backgroundPositionX = await store.get<number>("launcher_background_position_x");
+      setLauncherBackgroundPositionXState(clamp(backgroundPositionX ?? DEFAULT_BACKGROUND_POSITION, 0, 100));
+      const backgroundPositionY = await store.get<number>("launcher_background_position_y");
+      setLauncherBackgroundPositionYState(clamp(backgroundPositionY ?? DEFAULT_BACKGROUND_POSITION, 0, 100));
     });
   }, []);
 
@@ -35,6 +67,10 @@ export function useSettings(): Settings {
     const unlisten = listen<SettingsPayload>("settings-changed", (event) => {
       setApiEndpointState(event.payload.apiEndpoint);
       setTelemetryEnabledState(event.payload.telemetryEnabled);
+      setLauncherBackgroundPathState(event.payload.launcherBackgroundPath);
+      setLauncherBackgroundZoomState(event.payload.launcherBackgroundZoom);
+      setLauncherBackgroundPositionXState(event.payload.launcherBackgroundPositionX);
+      setLauncherBackgroundPositionYState(event.payload.launcherBackgroundPositionY);
     });
     return () => { unlisten.then((fn) => fn()); };
   }, []);
@@ -43,21 +79,96 @@ export function useSettings(): Settings {
     emitTo("main", "settings-changed", next);
   }, []);
 
+  const emitCurrent = useCallback((overrides: Partial<SettingsPayload>) => {
+    emit({
+      apiEndpoint,
+      telemetryEnabled,
+      launcherBackgroundPath,
+      launcherBackgroundZoom,
+      launcherBackgroundPositionX,
+      launcherBackgroundPositionY,
+      ...overrides,
+    });
+  }, [
+    emit,
+    apiEndpoint,
+    telemetryEnabled,
+    launcherBackgroundPath,
+    launcherBackgroundZoom,
+    launcherBackgroundPositionX,
+    launcherBackgroundPositionY,
+  ]);
+
   const setApiEndpoint = useCallback(async (endpoint: string) => {
     setApiEndpointState(endpoint);
     const store = await getStore();
     await store.set("api_endpoint", endpoint);
     await store.save();
-    emit({ apiEndpoint: endpoint, telemetryEnabled });
-  }, [emit, telemetryEnabled]);
+    emitCurrent({ apiEndpoint: endpoint });
+  }, [emitCurrent]);
 
   const setTelemetryEnabled = useCallback(async (enabled: boolean) => {
     setTelemetryEnabledState(enabled);
     const store = await getStore();
     await store.set("telemetry_enabled", enabled);
     await store.save();
-    emit({ apiEndpoint, telemetryEnabled: enabled });
-  }, [emit, apiEndpoint]);
+    emitCurrent({ telemetryEnabled: enabled });
+  }, [emitCurrent]);
+
+  const setLauncherBackgroundPath = useCallback(async (path: string | null) => {
+    setLauncherBackgroundPathState(path);
+    const store = await getStore();
+    if (path) {
+      await store.set("launcher_background_path", path);
+    } else {
+      await store.delete("launcher_background_path");
+    }
+    await store.save();
+    emitCurrent({ launcherBackgroundPath: path });
+  }, [emitCurrent]);
+
+  const setLauncherBackgroundZoom = useCallback(async (zoom: number) => {
+    const next = clamp(zoom, 100, 250);
+    setLauncherBackgroundZoomState(next);
+    const store = await getStore();
+    await store.set("launcher_background_zoom", next);
+    await store.save();
+    emitCurrent({ launcherBackgroundZoom: next });
+  }, [emitCurrent]);
+
+  const setLauncherBackgroundPositionX = useCallback(async (position: number) => {
+    const next = clamp(position, 0, 100);
+    setLauncherBackgroundPositionXState(next);
+    const store = await getStore();
+    await store.set("launcher_background_position_x", next);
+    await store.save();
+    emitCurrent({ launcherBackgroundPositionX: next });
+  }, [emitCurrent]);
+
+  const setLauncherBackgroundPositionY = useCallback(async (position: number) => {
+    const next = clamp(position, 0, 100);
+    setLauncherBackgroundPositionYState(next);
+    const store = await getStore();
+    await store.set("launcher_background_position_y", next);
+    await store.save();
+    emitCurrent({ launcherBackgroundPositionY: next });
+  }, [emitCurrent]);
+
+  const resetLauncherBackgroundLayout = useCallback(async () => {
+    setLauncherBackgroundZoomState(DEFAULT_BACKGROUND_ZOOM);
+    setLauncherBackgroundPositionXState(DEFAULT_BACKGROUND_POSITION);
+    setLauncherBackgroundPositionYState(DEFAULT_BACKGROUND_POSITION);
+    const store = await getStore();
+    await store.delete("launcher_background_zoom");
+    await store.delete("launcher_background_position_x");
+    await store.delete("launcher_background_position_y");
+    await store.save();
+    emitCurrent({
+      launcherBackgroundZoom: DEFAULT_BACKGROUND_ZOOM,
+      launcherBackgroundPositionX: DEFAULT_BACKGROUND_POSITION,
+      launcherBackgroundPositionY: DEFAULT_BACKGROUND_POSITION,
+    });
+  }, [emitCurrent]);
 
   return {
     apiEndpoint,
@@ -65,5 +176,14 @@ export function useSettings(): Settings {
     apiUrl: getApiUrl(apiEndpoint),
     telemetryEnabled,
     setTelemetryEnabled,
+    launcherBackgroundPath,
+    setLauncherBackgroundPath,
+    launcherBackgroundZoom,
+    setLauncherBackgroundZoom,
+    launcherBackgroundPositionX,
+    setLauncherBackgroundPositionX,
+    launcherBackgroundPositionY,
+    setLauncherBackgroundPositionY,
+    resetLauncherBackgroundLayout,
   };
 }


### PR DESCRIPTION
## Summary

Adds a local-only launcher background customization option.

Users can now choose an image from disk and adjust how it is framed in the launcher without shipping or hard-coding any external artwork or URLs.

## Changes

- Add an Appearance section to launcher settings for selecting a local background image.
- Validate selected images on the Tauri side and limit them to PNG, JPG, WebP, or GIF files up to 25 MiB.
- Render the selected local image as the launcher background.
- Persist background path and layout settings in the existing settings store.
- Add layout controls for selected backgrounds:
  - Zoom: 100%–250%
  - Horizontal position: 0%–100%
  - Vertical position: 0%–100%
  - Reset Position
- Make launcher panels slightly translucent so the selected background remains visible while preserving readability.

## Notes

- This intentionally does not include an example image.
- This intentionally does not hard-code or fetch any external image URL.

## Visual reference
<img width="680" height="269" alt="Screenshot 2026-05-29 133618" src="https://github.com/user-attachments/assets/47d70e9d-76c4-49d3-ae50-3fce76772340" />
<img width="899" height="565" alt="Screenshot 2026-05-29 131845" src="https://github.com/user-attachments/assets/2daafbba-fede-4d22-9554-285a0d034aa0" />

The intended result is:

- Main launcher: selected local image visible behind the server list and controls.
- Settings: local background picker with Browse/Reset plus Zoom, Horizontal, Vertical, and Reset Position controls.

## Testing

- [x] `bun run build`
- [x] `cargo check`
- [x] `tauri build --no-bundle`
- [x] Launched the built Windows executable and verified a selected local image renders behind the launcher.
