### PR TITLE
Add mounted net message visitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@ A server-side modding framework for [Deadlock](https://store.steampowered.com/ap
 
 > **Early development** — APIs are not finalized and will change without notice. We are not distributing prebuilt binaries at this time. Early users and contributors should build from source.
 
+## Visitor/usercmd additions
+
+This branch adds packaged Deadworks visitor controls on top of Deadworks' native hook chassis:
+
+- mounted usercmd policy (`off`, `count`, `direct`, `fast`, `serialize`, `mounted`);
+- read-only compact `FastUsercmd` callbacks for buttons/view/movement without full protobuf parsing;
+- native button edge triggers;
+- capability discovery via `NativeFeatures`.
+
+See [`docs/usercmd-visitors.md`](docs/usercmd-visitors.md) and [`config/deadworks_usercmd_visitors.env.example`](config/deadworks_usercmd_visitors.env.example).
+
 ## Prerequisites
 
 ### Visual Studio

--- a/README.md
+++ b/README.md
@@ -4,16 +4,19 @@ A server-side modding framework for [Deadlock](https://store.steampowered.com/ap
 
 > **Early development** — APIs are not finalized and will change without notice. We are not distributing prebuilt binaries at this time. Early users and contributors should build from source.
 
-## Visitor/usercmd additions
+## Visitor additions
 
 This branch adds packaged Deadworks visitor controls on top of Deadworks' native hook chassis:
 
 - mounted usercmd policy (`off`, `count`, `direct`, `fast`, `serialize`, `mounted`);
 - read-only compact `FastUsercmd` callbacks for buttons/view/movement without full protobuf parsing;
 - native button edge triggers;
-- capability discovery via `NativeFeatures`.
+- net-message interest gates so full protobuf serialization only happens for mounted handlers;
+- read-only compact `FastNetMessageEvent` callbacks for selected pause/user-message fields;
+- capability discovery via `NativeFeatures`;
+- `examples/plugins/DiagnosticsPlugin` for local visitor/command smoke testing.
 
-See [`docs/usercmd-visitors.md`](docs/usercmd-visitors.md) and [`config/deadworks_usercmd_visitors.env.example`](config/deadworks_usercmd_visitors.env.example).
+See [`docs/usercmd-visitors.md`](docs/usercmd-visitors.md), [`docs/net-message-visitors.md`](docs/net-message-visitors.md), [`config/deadworks_usercmd_visitors.env.example`](config/deadworks_usercmd_visitors.env.example), and [`config/deadworks_net_visitors.env.example`](config/deadworks_net_visitors.env.example).
 
 ## Prerequisites
 

--- a/config/deadworks_net_visitors.env.example
+++ b/config/deadworks_net_visitors.env.example
@@ -1,0 +1,8 @@
+# Optional net-message visitor diagnostics.
+# Normal plugin interest is declared in managed code through NetMessages.Visit* or Hook* APIs.
+
+# Emit aggregate counters from incoming/outgoing net-message hooks.
+# DEADWORKS_NETMSG_PROBE_LOG=1
+
+# Probe log interval in milliseconds (default: 5000).
+# DEADWORKS_NETMSG_PROBE_LOG_WINDOW_MS=5000

--- a/config/deadworks_usercmd_visitors.env.example
+++ b/config/deadworks_usercmd_visitors.env.example
@@ -1,0 +1,28 @@
+# Deadworks usercmd visitor profile
+# Copy into your server environment when you want to force a native usercmd mode
+# without plugin-side registration. Defaults are conservative.
+
+# Use mounted policy. With no mounted features this only counts batches and
+# immediately returns to the engine.
+DEADWORKS_USERCMD_NATIVE_MODE=mounted
+
+# Optional startup mounts. Plugins can also mount these via DeadworksManaged.Api.Usercmds.
+# Values: full, fast, trigger, all, or a numeric bitmask.
+# - full: legacy CCitadelUserCmdPB protobuf parse/mutation path
+# - fast: read-only native-extracted fields (tick/buttons/view/move)
+# - trigger: native button edge predicates only
+DEADWORKS_USERCMD_MOUNTS=fast
+
+# Fast visitor fields. Values: all, tick, buttons, view, movement, or a numeric bitmask.
+DEADWORKS_USERCMD_FIELDS=buttons,view,movement
+
+# Buttons watched by the trigger mount. Use a numeric InputButton ulong mask or "all".
+# Example: Ability1 (0x200000000) | Attack (0x1) = 0x200000001
+DEADWORKS_USERCMD_BUTTON_TRIGGER_MASK=0x200000001
+
+# Optional benchmark logging. Emits [UsercmdVisitor] aggregate counters per slot.
+DEADWORKS_USERCMD_PROBE_LOG=0
+DEADWORKS_USERCMD_PROBE_LOG_WINDOW_MS=5000
+
+# Hard off switch. Native checks this before protobuf serialization.
+DEADWORKS_DISABLE_USERCMDS=0

--- a/deadworks/deadworks.vcxproj
+++ b/deadworks/deadworks.vcxproj
@@ -207,6 +207,7 @@ if not "$(DeadlockDir)"=="" if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(
     <ClCompile Include="src\Core\Hooks\InitializeHeroOnPawn.cpp" />
     <ClCompile Include="src\Core\A2SPatch.cpp" />
     <ClCompile Include="src\Core\UsercmdVisitorRuntime.cpp" />
+    <ClCompile Include="src\Core\NetMessageVisitorRuntime.cpp" />
     <ClCompile Include="src\Core\Deadworks.cpp" />
     <ClCompile Include="src\Core\NativeCallbacks.cpp" />
     <ClCompile Include="src\Core\NativeAbility.cpp" />
@@ -257,6 +258,7 @@ if not "$(DeadlockDir)"=="" if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(
     <ClInclude Include="src\Core\Hooks\BuildGameSessionManifest.hpp" />
     <ClInclude Include="src\Core\A2SPatch.hpp" />
     <ClInclude Include="src\Core\UsercmdVisitorRuntime.hpp" />
+    <ClInclude Include="src\Core\NetMessageVisitorRuntime.hpp" />
     <ClInclude Include="src\Core\Deadworks.hpp" />
     <ClInclude Include="src\Core\NativeCallbacks.hpp" />
     <ClInclude Include="src\Core\NativeOffsets.hpp" />

--- a/deadworks/deadworks.vcxproj
+++ b/deadworks/deadworks.vcxproj
@@ -206,6 +206,7 @@ if not "$(DeadlockDir)"=="" if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(
     <ClCompile Include="src\Core\Hooks\CheckTransmit.cpp" />
     <ClCompile Include="src\Core\Hooks\InitializeHeroOnPawn.cpp" />
     <ClCompile Include="src\Core\A2SPatch.cpp" />
+    <ClCompile Include="src\Core\UsercmdVisitorRuntime.cpp" />
     <ClCompile Include="src\Core\Deadworks.cpp" />
     <ClCompile Include="src\Core\NativeCallbacks.cpp" />
     <ClCompile Include="src\Core\NativeAbility.cpp" />
@@ -255,6 +256,7 @@ if not "$(DeadlockDir)"=="" if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(
     <ClInclude Include="src\Core\Hooks\InitializeHeroOnPawn.hpp" />
     <ClInclude Include="src\Core\Hooks\BuildGameSessionManifest.hpp" />
     <ClInclude Include="src\Core\A2SPatch.hpp" />
+    <ClInclude Include="src\Core\UsercmdVisitorRuntime.hpp" />
     <ClInclude Include="src\Core\Deadworks.hpp" />
     <ClInclude Include="src\Core\NativeCallbacks.hpp" />
     <ClInclude Include="src\Core\NativeOffsets.hpp" />

--- a/deadworks/deadworks.vcxproj.filters
+++ b/deadworks/deadworks.vcxproj.filters
@@ -30,6 +30,9 @@
     <ClCompile Include="src\Core\UsercmdVisitorRuntime.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\Core\NetMessageVisitorRuntime.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\Core\Deadworks.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -180,6 +183,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\Core\UsercmdVisitorRuntime.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\Core\NetMessageVisitorRuntime.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\Core\Deadworks.hpp">

--- a/deadworks/deadworks.vcxproj.filters
+++ b/deadworks/deadworks.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClCompile Include="src\Core\A2SPatch.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\Core\UsercmdVisitorRuntime.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="src\Core\Deadworks.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -174,6 +177,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\Core\A2SPatch.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\Core\UsercmdVisitorRuntime.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\Core\Deadworks.hpp">

--- a/deadworks/src/Core/Deadworks.cpp
+++ b/deadworks/src/Core/Deadworks.cpp
@@ -588,6 +588,16 @@ void Deadworks::OnPre_ProcessUsercmds(int playerSlot, const uint8_t *batchBytes,
         m_managed.onProcessUsercmds(playerSlot, batchBytes, batchLen, numCmds, paused ? 1 : 0, margin, outBytes, outLen);
 }
 
+void Deadworks::OnFast_ProcessUsercmds(int playerSlot, const FastUsercmdNative *cmds, int numCmds, bool paused, float margin) {
+    if (m_managed.onFastProcessUsercmds)
+        m_managed.onFastProcessUsercmds(playerSlot, cmds, numCmds, paused ? 1 : 0, margin);
+}
+
+void Deadworks::OnUsercmdTrigger(int playerSlot, const FastUsercmdNative *cmd, uint64_t pressedButtons, uint64_t triggerButtons, bool paused, float margin) {
+    if (m_managed.onUsercmdTrigger)
+        m_managed.onUsercmdTrigger(playerSlot, cmd, pressedButtons, triggerButtons, paused ? 1 : 0, margin);
+}
+
 uint64_t Deadworks::OnPre_AbilityThink(int playerSlot, void *pawnEntity, uint64_t heldButtons, uint64_t changedButtons, uint64_t scrollButtons, uint64_t *outForcedButtons) {
     if (m_managed.onAbilityAttempt)
         return m_managed.onAbilityAttempt(playerSlot, pawnEntity, heldButtons, changedButtons, scrollButtons, outForcedButtons);

--- a/deadworks/src/Core/Deadworks.cpp
+++ b/deadworks/src/Core/Deadworks.cpp
@@ -2,6 +2,7 @@
 #include "NativeCallbacks.hpp"
 #include "NativeHero.hpp"
 #include "ManagedCallbacks.hpp"
+#include "NetMessageVisitorRuntime.hpp"
 
 #include "Hooks/CoreHooks.hpp"
 #include "Hooks/Source2GameClients.hpp"
@@ -34,6 +35,7 @@
 #include <tier1/convar.h>
 
 #include <netmessages.h>
+#include <netmessages.pb.h>
 #include <serversideclient.h>
 #include <irecipientfilter.h>
 #include <igameevents.h>
@@ -351,7 +353,40 @@ int Deadworks::OnPre_GameEvent(const char *eventName, void *eventPtr) {
 }
 
 bool Deadworks::OnPre_PostEventAbstract(int msgId, const CNetMessage *pData, uint64 *clientsMask) {
-    if (!m_managed.onNetMessageOutgoing || !pData)
+    if (!pData)
+        return false;
+
+    ProcessFastNetMessage(NetMessageDirection::Outgoing, -1, msgId, pData, clientsMask ? *clientsMask : 0);
+    LogNetMessageVisitorStatsIfDue();
+
+    if (!m_managed.onNetMessageOutgoing || !clientsMask)
+        return false;
+
+    static thread_local uint8_t outBuf[65536];
+
+    if (msgId == svc_UserMessage && HasAnyUserMessageSerializedInterest()) {
+        auto *pb = pData->AsMessageLite();
+        auto *user = pb ? static_cast<const CSVCMsg_UserMessage *>(pb) : nullptr;
+        if (user && user->has_msg_type() && HasUserMessageSerializedInterest(user->msg_type())) {
+            const std::string &payload = user->msg_data();
+            int outLen = -1;
+            uint64 outRecipientMask = *clientsMask;
+            int result = m_managed.onNetMessageOutgoing(
+                user->msg_type(), reinterpret_cast<const uint8_t *>(payload.data()), static_cast<int>(payload.size()),
+                *clientsMask, outBuf, &outLen, &outRecipientMask);
+
+            *clientsMask = outRecipientMask;
+            if (outLen >= 0)
+                const_cast<CSVCMsg_UserMessage *>(user)->set_msg_data(outBuf, outLen);
+
+            if (result >= 1)
+                return true;
+            if (!HasNetMessageSerializedInterest(NetMessageDirection::Outgoing, msgId))
+                return false;
+        }
+    }
+
+    if (!HasNetMessageSerializedInterest(NetMessageDirection::Outgoing, msgId))
         return false;
 
     auto *pb = pData->AsMessageLite();
@@ -366,15 +401,14 @@ bool Deadworks::OnPre_PostEventAbstract(int msgId, const CNetMessage *pData, uin
     if (!pb->SerializeToArray(buf.data(), size))
         return false;
 
-    static thread_local uint8_t outBuf[65536];
-    int outLen = 0;
+    int outLen = -1;
     uint64 outRecipientMask = *clientsMask;
 
     int result = m_managed.onNetMessageOutgoing(msgId, buf.data(), size, *clientsMask, outBuf, &outLen, &outRecipientMask);
 
     *clientsMask = outRecipientMask;
 
-    if (outLen > 0) {
+    if (outLen >= 0) {
         auto *mutablePb = const_cast<google::protobuf::MessageLite *>(pb);
         mutablePb->ParseFromArray(outBuf, outLen);
     }
@@ -519,20 +553,32 @@ void Deadworks::On_ISource2GameClients_ClientDisconnect(CPlayerSlot slot, ENetwo
 }
 
 std::optional<bool> Deadworks::OnPre_CServerSideClientBase_FilterMessage(INetworkMessageProcessingPreFilter *thisptr, const CNetMessage *pData) {
-    auto *client = static_cast<CServerSideClientBase *>(thisptr);
-    auto *info = pData->GetSerializerPB()->GetNetMessageInfo();
+    if (!pData)
+        return std::nullopt;
 
-    // Forward all incoming messages to managed for generic hook dispatch
-    if (m_managed.onNetMessageIncoming) {
-        int msgId = info->m_MessageId;
+    auto *client = static_cast<CServerSideClientBase *>(thisptr);
+    auto *serializer = pData->GetSerializerPB();
+    if (!serializer)
+        return std::nullopt;
+
+    auto *info = serializer->GetNetMessageInfo();
+    if (!info)
+        return std::nullopt;
+
+    int msgId = info->m_MessageId;
+    int senderSlot = client ? client->GetPlayerSlot().Get() : -1;
+
+    ProcessFastNetMessage(NetMessageDirection::Incoming, senderSlot, msgId, pData, 0);
+    LogNetMessageVisitorStatsIfDue();
+
+    if (m_managed.onNetMessageIncoming && HasNetMessageSerializedInterest(NetMessageDirection::Incoming, msgId)) {
         auto *pb = pData->AsMessageLite();
         if (pb) {
             int size = static_cast<int>(pb->ByteSizeLong());
             if (size > 0) {
                 std::vector<uint8_t> buf(size);
                 if (pb->SerializeToArray(buf.data(), size)) {
-                    int result = m_managed.onNetMessageIncoming(
-                        client->GetPlayerSlot().Get(), msgId, buf.data(), size);
+                    int result = m_managed.onNetMessageIncoming(senderSlot, msgId, buf.data(), size);
                     if (result >= 1) // Stop/block
                         return true;
                 }
@@ -596,6 +642,22 @@ void Deadworks::OnFast_ProcessUsercmds(int playerSlot, const FastUsercmdNative *
 void Deadworks::OnUsercmdTrigger(int playerSlot, const FastUsercmdNative *cmd, uint64_t pressedButtons, uint64_t triggerButtons, bool paused, float margin) {
     if (m_managed.onUsercmdTrigger)
         m_managed.onUsercmdTrigger(playerSlot, cmd, pressedButtons, triggerButtons, paused ? 1 : 0, margin);
+}
+
+bool Deadworks::HasFastNetMessageCallback() const {
+    return m_managed.onFastNetMessage != nullptr;
+}
+
+void Deadworks::OnFastNetMessage(int32_t direction, int32_t endpointSlot, int32_t msgId, uint64_t recipientMask,
+                                 int32_t userMessageType, uint8_t hasUserMessageType,
+                                 int32_t pauseType, int32_t pauseGroup, uint8_t hasPauseRequest,
+                                 uint8_t paused, uint8_t hasPauseState) {
+    if (m_managed.onFastNetMessage) {
+        m_managed.onFastNetMessage(direction, endpointSlot, msgId, recipientMask,
+                                   userMessageType, hasUserMessageType,
+                                   pauseType, pauseGroup, hasPauseRequest,
+                                   paused, hasPauseState);
+    }
 }
 
 uint64_t Deadworks::OnPre_AbilityThink(int playerSlot, void *pawnEntity, uint64_t heldButtons, uint64_t changedButtons, uint64_t scrollButtons, uint64_t *outForcedButtons) {

--- a/deadworks/src/Core/Deadworks.hpp
+++ b/deadworks/src/Core/Deadworks.hpp
@@ -86,6 +86,12 @@ public:
     void OnPre_ProcessUsercmds(int playerSlot, const uint8_t *batchBytes, int batchLen, int numCmds, bool paused, float margin, uint8_t *outBytes, int *outLen);
     void OnFast_ProcessUsercmds(int playerSlot, const FastUsercmdNative *cmds, int numCmds, bool paused, float margin);
     void OnUsercmdTrigger(int playerSlot, const FastUsercmdNative *cmd, uint64_t pressedButtons, uint64_t triggerButtons, bool paused, float margin);
+    // Fast net message visitors
+    bool HasFastNetMessageCallback() const;
+    void OnFastNetMessage(int32_t direction, int32_t endpointSlot, int32_t msgId, uint64_t recipientMask,
+                          int32_t userMessageType, uint8_t hasUserMessageType,
+                          int32_t pauseType, int32_t pauseGroup, uint8_t hasPauseRequest,
+                          uint8_t paused, uint8_t hasPauseState);
     // Ability think - returns bitmask of buttons to block, outForcedButtons receives bits to force
     uint64_t OnPre_AbilityThink(int playerSlot, void *pawnEntity, uint64_t heldButtons, uint64_t changedButtons, uint64_t scrollButtons, uint64_t *outForcedButtons);
     // AddModifier

--- a/deadworks/src/Core/Deadworks.hpp
+++ b/deadworks/src/Core/Deadworks.hpp
@@ -84,6 +84,8 @@ public:
                                  void *activator, void *caller, const void *variantValue, float delay);
     // Usercmds
     void OnPre_ProcessUsercmds(int playerSlot, const uint8_t *batchBytes, int batchLen, int numCmds, bool paused, float margin, uint8_t *outBytes, int *outLen);
+    void OnFast_ProcessUsercmds(int playerSlot, const FastUsercmdNative *cmds, int numCmds, bool paused, float margin);
+    void OnUsercmdTrigger(int playerSlot, const FastUsercmdNative *cmd, uint64_t pressedButtons, uint64_t triggerButtons, bool paused, float margin);
     // Ability think - returns bitmask of buttons to block, outForcedButtons receives bits to force
     uint64_t OnPre_AbilityThink(int playerSlot, void *pawnEntity, uint64_t heldButtons, uint64_t changedButtons, uint64_t scrollButtons, uint64_t *outForcedButtons);
     // AddModifier

--- a/deadworks/src/Core/Hooks/ProcessUsercmds.cpp
+++ b/deadworks/src/Core/Hooks/ProcessUsercmds.cpp
@@ -1,85 +1,16 @@
 #include "ProcessUsercmds.hpp"
 
-#include "../Deadworks.hpp"
+#include "../UsercmdVisitorRuntime.hpp"
 #include "../../SDK/CBaseEntity.hpp"
-
-#include <google/protobuf/message_lite.h>
 
 namespace deadworks {
 namespace hooks {
-
-// CUserCmd layout (from IDA reverse engineering):
-// 0x00: vtable ptr (CUserCmdBase/CUserCmd)
-// 0x08: int (command tick/state)
-// 0x10: CCitadelUserCmdPB (MessageLite-derived, inherits through CUserCmdBaseHost)
-// Total stride: 0xA8 (168 bytes)
-static constexpr size_t kCUserCmdStride = 0xA8;
-static constexpr size_t kProtobufOffset = 0x10;
 
 void *__fastcall Hook_ProcessUsercmds(void *pController, void *cmds, int numcmds, unsigned char paused, float margin) {
     auto *entity = static_cast<CBaseEntity *>(reinterpret_cast<CEntityInstance *>(pController));
     int slot = entity->GetRefEHandle().GetEntryIndex() - 1;
 
-    if (slot >= 0 && slot < 64 && numcmds > 0) {
-        // Build a buffer with all serialized usercmds: [len1][bytes1][len2][bytes2]...
-        static thread_local std::vector<uint8_t> batchBuf;
-        batchBuf.clear();
-
-        // Track which native cmd indices had valid protos (for deserialization back)
-        static thread_local std::vector<int> validCmdIndices;
-        validCmdIndices.clear();
-
-        for (int i = 0; i < numcmds; i++) {
-            auto *cmdBase = reinterpret_cast<char *>(cmds) + (i * kCUserCmdStride);
-            auto *pb = reinterpret_cast<google::protobuf::MessageLite *>(cmdBase + kProtobufOffset);
-
-            int size = static_cast<int>(pb->ByteSizeLong());
-            if (size <= 0)
-                continue;
-
-            // Append length prefix (4 bytes, little-endian)
-            size_t offset = batchBuf.size();
-            batchBuf.resize(offset + 4 + size);
-            memcpy(batchBuf.data() + offset, &size, 4);
-
-            if (!pb->SerializeToArray(batchBuf.data() + offset + 4, size)) {
-                batchBuf.resize(offset); // rollback on failure
-                continue;
-            }
-
-            validCmdIndices.push_back(i);
-        }
-
-        if (!validCmdIndices.empty()) {
-            static thread_local uint8_t outBuf[65536];
-            int outLen = 0;
-
-            g_Deadworks.OnPre_ProcessUsercmds(slot, batchBuf.data(),
-                                               static_cast<int>(batchBuf.size()),
-                                               static_cast<int>(validCmdIndices.size()),
-                                               paused != 0, margin,
-                                               outBuf, &outLen);
-
-            // If managed code returned modified bytes, deserialize back into native protos
-            if (outLen > 0) {
-                int offset = 0;
-                for (size_t idx = 0; idx < validCmdIndices.size() && offset + 4 <= outLen; idx++) {
-                    int len;
-                    memcpy(&len, outBuf + offset, 4);
-                    offset += 4;
-
-                    if (len <= 0 || offset + len > outLen)
-                        break;
-
-                    auto *cmdBase = reinterpret_cast<char *>(cmds) + (validCmdIndices[idx] * kCUserCmdStride);
-                    auto *pb = reinterpret_cast<google::protobuf::MessageLite *>(cmdBase + kProtobufOffset);
-                    pb->ParseFromArray(outBuf + offset, len);
-
-                    offset += len;
-                }
-            }
-        }
-    }
+    ProcessUsercmdVisitors(slot, cmds, numcmds, paused, margin);
 
     return g_ProcessUsercmds.thiscall<void *>(pController, cmds, numcmds, paused, margin);
 }

--- a/deadworks/src/Core/ManagedCallbacks.cpp
+++ b/deadworks/src/Core/ManagedCallbacks.cpp
@@ -71,6 +71,8 @@ void deadworks::InitializeManagedCallbacks(DotNetHost &host, ManagedCallbacks &m
     BindCallback(host, assemblyPath, managed.onEntityFireOutput, L"OnEntityFireOutput");
     BindCallback(host, assemblyPath, managed.onEntityFireOutputPost, L"OnEntityFireOutputPost");
     BindCallback(host, assemblyPath, managed.onProcessUsercmds, L"OnProcessUsercmds");
+    BindCallback(host, assemblyPath, managed.onFastProcessUsercmds, L"OnFastProcessUsercmds");
+    BindCallback(host, assemblyPath, managed.onUsercmdTrigger, L"OnUsercmdTrigger");
     BindCallback(host, assemblyPath, managed.onAbilityAttempt, L"OnAbilityAttempt");
     BindCallback(host, assemblyPath, g_ManagedConCommandDispatch, L"OnConCommandDispatch");
     BindCallback(host, assemblyPath, managed.onAddModifier, L"OnAddModifier");

--- a/deadworks/src/Core/ManagedCallbacks.cpp
+++ b/deadworks/src/Core/ManagedCallbacks.cpp
@@ -73,6 +73,7 @@ void deadworks::InitializeManagedCallbacks(DotNetHost &host, ManagedCallbacks &m
     BindCallback(host, assemblyPath, managed.onProcessUsercmds, L"OnProcessUsercmds");
     BindCallback(host, assemblyPath, managed.onFastProcessUsercmds, L"OnFastProcessUsercmds");
     BindCallback(host, assemblyPath, managed.onUsercmdTrigger, L"OnUsercmdTrigger");
+    BindCallback(host, assemblyPath, managed.onFastNetMessage, L"OnFastNetMessage");
     BindCallback(host, assemblyPath, managed.onAbilityAttempt, L"OnAbilityAttempt");
     BindCallback(host, assemblyPath, g_ManagedConCommandDispatch, L"OnConCommandDispatch");
     BindCallback(host, assemblyPath, managed.onAddModifier, L"OnAddModifier");

--- a/deadworks/src/Core/ManagedCallbacks.hpp
+++ b/deadworks/src/Core/ManagedCallbacks.hpp
@@ -60,6 +60,10 @@ struct ManagedCallbacks {
     using OnProcessUsercmdsFn = void(CORECLR_DELEGATE_CALLTYPE *)(int playerSlot, const uint8_t *batchBytes, int batchLen, int numCmds, uint8_t paused, float margin, uint8_t *outBatchBytes, int *outBatchLen);
     using OnFastProcessUsercmdsFn = void(CORECLR_DELEGATE_CALLTYPE *)(int playerSlot, const FastUsercmdNative *cmds, int numCmds, uint8_t paused, float margin);
     using OnUsercmdTriggerFn = void(CORECLR_DELEGATE_CALLTYPE *)(int playerSlot, const FastUsercmdNative *cmd, uint64_t pressedButtons, uint64_t triggerButtons, uint8_t paused, float margin);
+    using OnFastNetMessageFn = void(CORECLR_DELEGATE_CALLTYPE *)(int32_t direction, int32_t endpointSlot, int32_t msgId, uint64_t recipientMask,
+                                                                 int32_t userMessageType, uint8_t hasUserMessageType,
+                                                                 int32_t pauseType, int32_t pauseGroup, uint8_t hasPauseRequest,
+                                                                 uint8_t paused, uint8_t hasPauseState);
     using OnAbilityAttemptFn = uint64_t(CORECLR_DELEGATE_CALLTYPE *)(int playerSlot, void *pawnEntity, uint64_t heldButtons, uint64_t changedButtons, uint64_t scrollButtons, uint64_t *outForcedButtons);
     using OnAddModifierFn = int(CORECLR_DELEGATE_CALLTYPE *)(void *modifierProp, void **pCaster, uint32_t *pHAbility, int32_t *pITeam, void *vdata, void *params, void *kv);
     using OnCheckTransmitFn = void(CORECLR_DELEGATE_CALLTYPE *)(int playerSlot, void *transmitBits);
@@ -90,6 +94,7 @@ struct ManagedCallbacks {
     OnProcessUsercmdsFn onProcessUsercmds = nullptr;
     OnFastProcessUsercmdsFn onFastProcessUsercmds = nullptr;
     OnUsercmdTriggerFn onUsercmdTrigger = nullptr;
+    OnFastNetMessageFn onFastNetMessage = nullptr;
     OnAbilityAttemptFn onAbilityAttempt = nullptr;
     OnAddModifierFn onAddModifier = nullptr;
     OnCheckTransmitFn onCheckTransmit = nullptr;

--- a/deadworks/src/Core/ManagedCallbacks.hpp
+++ b/deadworks/src/Core/ManagedCallbacks.hpp
@@ -7,6 +7,21 @@ namespace deadworks {
 
 class DotNetHost;
 
+struct FastUsercmdNative {
+    int32_t commandIndex;
+    int32_t clientTick;
+    uint64_t buttons;
+    float pitch;
+    float yaw;
+    float roll;
+    float forwardMove;
+    float leftMove;
+    int32_t hasBase;
+    int32_t hasButtons;
+    int32_t hasViewAngles;
+};
+static_assert(sizeof(FastUsercmdNative) == 48, "FastUsercmdNative ABI must match managed FastUsercmd");
+
 struct ManagedCallbacks {
     using OnStartupServerFn = void(CORECLR_DELEGATE_CALLTYPE *)(const char *mapName);
     using OnTakeDamageOldFn = bool(CORECLR_DELEGATE_CALLTYPE *)(void *entity, void *info, void *result);
@@ -43,6 +58,8 @@ struct ManagedCallbacks {
                                                                        void *activator, void *caller,
                                                                        const void *variantValue, float delay);
     using OnProcessUsercmdsFn = void(CORECLR_DELEGATE_CALLTYPE *)(int playerSlot, const uint8_t *batchBytes, int batchLen, int numCmds, uint8_t paused, float margin, uint8_t *outBatchBytes, int *outBatchLen);
+    using OnFastProcessUsercmdsFn = void(CORECLR_DELEGATE_CALLTYPE *)(int playerSlot, const FastUsercmdNative *cmds, int numCmds, uint8_t paused, float margin);
+    using OnUsercmdTriggerFn = void(CORECLR_DELEGATE_CALLTYPE *)(int playerSlot, const FastUsercmdNative *cmd, uint64_t pressedButtons, uint64_t triggerButtons, uint8_t paused, float margin);
     using OnAbilityAttemptFn = uint64_t(CORECLR_DELEGATE_CALLTYPE *)(int playerSlot, void *pawnEntity, uint64_t heldButtons, uint64_t changedButtons, uint64_t scrollButtons, uint64_t *outForcedButtons);
     using OnAddModifierFn = int(CORECLR_DELEGATE_CALLTYPE *)(void *modifierProp, void **pCaster, uint32_t *pHAbility, int32_t *pITeam, void *vdata, void *params, void *kv);
     using OnCheckTransmitFn = void(CORECLR_DELEGATE_CALLTYPE *)(int playerSlot, void *transmitBits);
@@ -71,6 +88,8 @@ struct ManagedCallbacks {
     OnEntityFireOutputFn onEntityFireOutput = nullptr;
     OnEntityFireOutputPostFn onEntityFireOutputPost = nullptr;
     OnProcessUsercmdsFn onProcessUsercmds = nullptr;
+    OnFastProcessUsercmdsFn onFastProcessUsercmds = nullptr;
+    OnUsercmdTriggerFn onUsercmdTrigger = nullptr;
     OnAbilityAttemptFn onAbilityAttempt = nullptr;
     OnAddModifierFn onAddModifier = nullptr;
     OnCheckTransmitFn onCheckTransmit = nullptr;

--- a/deadworks/src/Core/NativeCallbacks.cpp
+++ b/deadworks/src/Core/NativeCallbacks.cpp
@@ -4,6 +4,7 @@
 #include "NativeDamage.hpp"
 #include "NativeHero.hpp"
 #include "Deadworks.hpp"
+#include "UsercmdVisitorRuntime.hpp"
 
 #include "Hooks/CCitadelPlayerPawn.hpp"
 #include "Hooks/CBaseEntity.hpp"
@@ -1021,6 +1022,65 @@ static uint32_t __cdecl NativeTakeSoundEventGuid() {
 }
 
 // ---------------------------------------------------------------------------
+// Deadworks visitor API
+// ---------------------------------------------------------------------------
+
+static uint32_t __cdecl NativeGetNativeApiVersion() {
+    return 1;
+}
+
+static uint8_t __cdecl NativeHasNativeCapability(const char *capability) {
+    if (!capability || !*capability)
+        return 0;
+
+    static constexpr const char *kCapabilities[] = {
+        "deadworks.visitors.v1",
+        "usercmd.mounted_policy",
+        "usercmd.full_protobuf_mount",
+        "usercmd.fast_read",
+        "usercmd.button_triggers",
+    };
+
+    for (const char *known : kCapabilities) {
+        if (std::strcmp(capability, known) == 0)
+            return 1;
+    }
+    return 0;
+}
+
+static void __cdecl NativeSetUsercmdNativeMode(int32_t mode) {
+    hooks::SetUsercmdNativeMode(mode);
+}
+
+static int32_t __cdecl NativeGetUsercmdNativeMode() {
+    return hooks::GetUsercmdNativeMode();
+}
+
+static void __cdecl NativeSetUsercmdMountMask(uint32_t mask) {
+    hooks::SetUsercmdMountMask(mask);
+}
+
+static uint32_t __cdecl NativeGetUsercmdMountMask() {
+    return hooks::GetUsercmdMountMask();
+}
+
+static void __cdecl NativeSetUsercmdButtonTriggerMask(uint64_t mask) {
+    hooks::SetUsercmdButtonTriggerMask(mask);
+}
+
+static uint64_t __cdecl NativeGetUsercmdButtonTriggerMask() {
+    return hooks::GetUsercmdButtonTriggerMask();
+}
+
+static void __cdecl NativeSetUsercmdFieldMask(uint32_t mask) {
+    hooks::SetUsercmdFieldMask(mask);
+}
+
+static uint32_t __cdecl NativeGetUsercmdFieldMask() {
+    return hooks::GetUsercmdFieldMask();
+}
+
+// ---------------------------------------------------------------------------
 // Resolve statics that PostInit needs
 // ---------------------------------------------------------------------------
 
@@ -1184,4 +1244,16 @@ void deadworks::PopulateNativeCallbacks(NativeCallbacks &callbacks) {
 
     // ConCommand flag mutation
     callbacks.AddConCommandFlags = &NativeAddConCommandFlags;
+
+    // Deadworks visitor API
+    callbacks.GetNativeApiVersion = &NativeGetNativeApiVersion;
+    callbacks.HasNativeCapability = &NativeHasNativeCapability;
+    callbacks.SetUsercmdNativeMode = &NativeSetUsercmdNativeMode;
+    callbacks.GetUsercmdNativeMode = &NativeGetUsercmdNativeMode;
+    callbacks.SetUsercmdMountMask = &NativeSetUsercmdMountMask;
+    callbacks.GetUsercmdMountMask = &NativeGetUsercmdMountMask;
+    callbacks.SetUsercmdButtonTriggerMask = &NativeSetUsercmdButtonTriggerMask;
+    callbacks.GetUsercmdButtonTriggerMask = &NativeGetUsercmdButtonTriggerMask;
+    callbacks.SetUsercmdFieldMask = &NativeSetUsercmdFieldMask;
+    callbacks.GetUsercmdFieldMask = &NativeGetUsercmdFieldMask;
 }

--- a/deadworks/src/Core/NativeCallbacks.cpp
+++ b/deadworks/src/Core/NativeCallbacks.cpp
@@ -5,6 +5,7 @@
 #include "NativeHero.hpp"
 #include "Deadworks.hpp"
 #include "UsercmdVisitorRuntime.hpp"
+#include "NetMessageVisitorRuntime.hpp"
 
 #include "Hooks/CCitadelPlayerPawn.hpp"
 #include "Hooks/CBaseEntity.hpp"
@@ -1026,7 +1027,7 @@ static uint32_t __cdecl NativeTakeSoundEventGuid() {
 // ---------------------------------------------------------------------------
 
 static uint32_t __cdecl NativeGetNativeApiVersion() {
-    return 1;
+    return 2;
 }
 
 static uint8_t __cdecl NativeHasNativeCapability(const char *capability) {
@@ -1039,6 +1040,10 @@ static uint8_t __cdecl NativeHasNativeCapability(const char *capability) {
         "usercmd.full_protobuf_mount",
         "usercmd.fast_read",
         "usercmd.button_triggers",
+        "netmsg.interest_gates",
+        "netmsg.fast_read",
+        "netmsg.user_message_interest_gates",
+        "netmsg.user_message_fast_read",
     };
 
     for (const char *known : kCapabilities) {
@@ -1078,6 +1083,42 @@ static void __cdecl NativeSetUsercmdFieldMask(uint32_t mask) {
 
 static uint32_t __cdecl NativeGetUsercmdFieldMask() {
     return hooks::GetUsercmdFieldMask();
+}
+
+static NetMessageDirection ToNetMessageDirection(int32_t direction) {
+    return direction == 0 ? NetMessageDirection::Incoming : NetMessageDirection::Outgoing;
+}
+
+static void __cdecl NativeSetNetMessageSerializedInterest(int32_t direction, int32_t msgId, uint8_t enabled) {
+    SetNetMessageSerializedInterest(ToNetMessageDirection(direction), msgId, enabled != 0);
+}
+
+static uint8_t __cdecl NativeHasNetMessageSerializedInterest(int32_t direction, int32_t msgId) {
+    return HasNetMessageSerializedInterest(ToNetMessageDirection(direction), msgId) ? 1 : 0;
+}
+
+static void __cdecl NativeSetNetMessageFastInterest(int32_t direction, int32_t msgId, uint8_t enabled) {
+    SetNetMessageFastInterest(ToNetMessageDirection(direction), msgId, enabled != 0);
+}
+
+static uint8_t __cdecl NativeHasNetMessageFastInterest(int32_t direction, int32_t msgId) {
+    return HasNetMessageFastInterest(ToNetMessageDirection(direction), msgId) ? 1 : 0;
+}
+
+static void __cdecl NativeSetUserMessageFastInterest(int32_t userMessageType, uint8_t enabled) {
+    SetUserMessageFastInterest(userMessageType, enabled != 0);
+}
+
+static uint8_t __cdecl NativeHasUserMessageFastInterest(int32_t userMessageType) {
+    return HasUserMessageFastInterest(userMessageType) ? 1 : 0;
+}
+
+static void __cdecl NativeSetUserMessageSerializedInterest(int32_t userMessageType, uint8_t enabled) {
+    SetUserMessageSerializedInterest(userMessageType, enabled != 0);
+}
+
+static uint8_t __cdecl NativeHasUserMessageSerializedInterest(int32_t userMessageType) {
+    return HasUserMessageSerializedInterest(userMessageType) ? 1 : 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -1256,4 +1297,12 @@ void deadworks::PopulateNativeCallbacks(NativeCallbacks &callbacks) {
     callbacks.GetUsercmdButtonTriggerMask = &NativeGetUsercmdButtonTriggerMask;
     callbacks.SetUsercmdFieldMask = &NativeSetUsercmdFieldMask;
     callbacks.GetUsercmdFieldMask = &NativeGetUsercmdFieldMask;
+    callbacks.SetNetMessageSerializedInterest = &NativeSetNetMessageSerializedInterest;
+    callbacks.HasNetMessageSerializedInterest = &NativeHasNetMessageSerializedInterest;
+    callbacks.SetNetMessageFastInterest = &NativeSetNetMessageFastInterest;
+    callbacks.HasNetMessageFastInterest = &NativeHasNetMessageFastInterest;
+    callbacks.SetUserMessageFastInterest = &NativeSetUserMessageFastInterest;
+    callbacks.HasUserMessageFastInterest = &NativeHasUserMessageFastInterest;
+    callbacks.SetUserMessageSerializedInterest = &NativeSetUserMessageSerializedInterest;
+    callbacks.HasUserMessageSerializedInterest = &NativeHasUserMessageSerializedInterest;
 }

--- a/deadworks/src/Core/NativeCallbacks.hpp
+++ b/deadworks/src/Core/NativeCallbacks.hpp
@@ -138,6 +138,19 @@ struct NativeCallbacks {
     void(__cdecl *VariantToVector)(const void *variantPtr, float *outXYZW);  // populates 4 floats; zero-pads unused components
     uint32_t(__cdecl *VariantToColor)(const void *variantPtr);  // packed RGBA (R in low byte)
     uint8_t(__cdecl *AddConCommandFlags)(const char *name, uint64_t flags);
+
+    // Optional visitor API. Keep new entries appended to preserve the existing
+    // callback layout for plugins that only use the older Deadworks surface.
+    uint32_t(__cdecl *GetNativeApiVersion)();
+    uint8_t(__cdecl *HasNativeCapability)(const char *capabilityName);
+    void(__cdecl *SetUsercmdNativeMode)(int32_t mode);
+    int32_t(__cdecl *GetUsercmdNativeMode)();
+    void(__cdecl *SetUsercmdMountMask)(uint32_t mask);
+    uint32_t(__cdecl *GetUsercmdMountMask)();
+    void(__cdecl *SetUsercmdButtonTriggerMask)(uint64_t mask);
+    uint64_t(__cdecl *GetUsercmdButtonTriggerMask)();
+    void(__cdecl *SetUsercmdFieldMask)(uint32_t mask);
+    uint32_t(__cdecl *GetUsercmdFieldMask)();
 };
 
 void PopulateNativeCallbacks(NativeCallbacks &callbacks);

--- a/deadworks/src/Core/NativeCallbacks.hpp
+++ b/deadworks/src/Core/NativeCallbacks.hpp
@@ -151,6 +151,14 @@ struct NativeCallbacks {
     uint64_t(__cdecl *GetUsercmdButtonTriggerMask)();
     void(__cdecl *SetUsercmdFieldMask)(uint32_t mask);
     uint32_t(__cdecl *GetUsercmdFieldMask)();
+    void(__cdecl *SetNetMessageSerializedInterest)(int32_t direction, int32_t msgId, uint8_t enabled);
+    uint8_t(__cdecl *HasNetMessageSerializedInterest)(int32_t direction, int32_t msgId);
+    void(__cdecl *SetNetMessageFastInterest)(int32_t direction, int32_t msgId, uint8_t enabled);
+    uint8_t(__cdecl *HasNetMessageFastInterest)(int32_t direction, int32_t msgId);
+    void(__cdecl *SetUserMessageFastInterest)(int32_t userMessageType, uint8_t enabled);
+    uint8_t(__cdecl *HasUserMessageFastInterest)(int32_t userMessageType);
+    void(__cdecl *SetUserMessageSerializedInterest)(int32_t userMessageType, uint8_t enabled);
+    uint8_t(__cdecl *HasUserMessageSerializedInterest)(int32_t userMessageType);
 };
 
 void PopulateNativeCallbacks(NativeCallbacks &callbacks);

--- a/deadworks/src/Core/NetMessageVisitorRuntime.cpp
+++ b/deadworks/src/Core/NetMessageVisitorRuntime.cpp
@@ -1,0 +1,320 @@
+#include "NetMessageVisitorRuntime.hpp"
+
+#include "Deadworks.hpp"
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+
+#include <networksystem/netmessage.h>
+#include <netmessages.pb.h>
+
+namespace deadworks {
+namespace {
+
+constexpr int kMaxTrackedMessageId = 4096;
+
+using InterestTable = std::array<std::atomic_uint8_t, kMaxTrackedMessageId>;
+
+InterestTable g_serializedIncoming{};
+InterestTable g_serializedOutgoing{};
+InterestTable g_fastIncoming{};
+InterestTable g_fastOutgoing{};
+InterestTable g_serializedUserMessages{};
+InterestTable g_fastUserMessages{};
+
+std::atomic_uint32_t g_serializedUserMessageInterestCount{0};
+std::atomic_uint32_t g_fastUserMessageInterestCount{0};
+std::atomic_uint32_t g_totalInterestCount{0};
+
+std::atomic_uint64_t g_incomingSeen{0};
+std::atomic_uint64_t g_outgoingSeen{0};
+std::atomic_uint64_t g_serializedIncomingHits{0};
+std::atomic_uint64_t g_serializedOutgoingHits{0};
+std::atomic_uint64_t g_fastIncomingCallbacks{0};
+std::atomic_uint64_t g_fastOutgoingCallbacks{0};
+std::atomic_uint64_t g_fastUserMessageCallbacks{0};
+std::atomic_uint64_t g_noInterestIncoming{0};
+std::atomic_uint64_t g_noInterestOutgoing{0};
+std::atomic_uint64_t g_directExceptions{0};
+
+std::chrono::steady_clock::time_point g_lastProbeLog{};
+
+bool IsValidMessageId(int32_t msgId) {
+    return msgId >= 0 && msgId < kMaxTrackedMessageId;
+}
+
+bool IsValidUserMessageType(int32_t userMessageType) {
+    return userMessageType >= 0 && userMessageType < kMaxTrackedMessageId;
+}
+
+bool HasAnyUserMessageFastInterest() {
+    return g_fastUserMessageInterestCount.load(std::memory_order_relaxed) != 0;
+}
+
+bool HasAnyInterest() {
+    return g_totalInterestCount.load(std::memory_order_relaxed) != 0;
+}
+
+void TrackTotalInterest(uint8_t wasEnabled, bool enabled) {
+    if (!wasEnabled && enabled) {
+        g_totalInterestCount.fetch_add(1, std::memory_order_relaxed);
+    } else if (wasEnabled && !enabled) {
+        g_totalInterestCount.fetch_sub(1, std::memory_order_relaxed);
+    }
+}
+
+void SetMessageInterest(InterestTable &table, int32_t msgId, bool enabled) {
+    if (!IsValidMessageId(msgId))
+        return;
+
+    auto &entry = table[static_cast<size_t>(msgId)];
+    uint8_t wasEnabled = entry.exchange(enabled ? 1 : 0, std::memory_order_relaxed);
+    TrackTotalInterest(wasEnabled, enabled);
+}
+
+void SetUserMessageInterest(InterestTable &table, std::atomic_uint32_t &count, int32_t userMessageType, bool enabled) {
+    if (!IsValidUserMessageType(userMessageType))
+        return;
+
+    auto &entry = table[static_cast<size_t>(userMessageType)];
+    uint8_t wasEnabled = entry.exchange(enabled ? 1 : 0, std::memory_order_relaxed);
+    if (!wasEnabled && enabled) {
+        count.fetch_add(1, std::memory_order_relaxed);
+    } else if (wasEnabled && !enabled) {
+        count.fetch_sub(1, std::memory_order_relaxed);
+    }
+    TrackTotalInterest(wasEnabled, enabled);
+}
+
+InterestTable &TableFor(NetMessageDirection direction, bool serialized) {
+    if (serialized)
+        return direction == NetMessageDirection::Incoming ? g_serializedIncoming : g_serializedOutgoing;
+    return direction == NetMessageDirection::Incoming ? g_fastIncoming : g_fastOutgoing;
+}
+
+bool EnvFlag(const char *name) {
+    if (const char *value = std::getenv(name)) {
+        return value[0] == '1' || value[0] == 't' || value[0] == 'T' || value[0] == 'y' || value[0] == 'Y';
+    }
+    return false;
+}
+
+bool ProbeLogEnabled() {
+    static const bool enabled = EnvFlag("DEADWORKS_NETMSG_PROBE_LOG");
+    return enabled;
+}
+
+int ProbeWindowMs() {
+    static const int windowMs = [] {
+        if (const char *value = std::getenv("DEADWORKS_NETMSG_PROBE_LOG_WINDOW_MS")) {
+            int parsed = std::atoi(value);
+            if (parsed > 0)
+                return parsed;
+        }
+        return 5000;
+    }();
+    return windowMs;
+}
+
+struct FastNetMessageNative {
+    int32_t userMessageType = -1;
+    uint8_t hasUserMessageType = 0;
+    int32_t pauseType = 0;
+    int32_t pauseGroup = 0;
+    uint8_t hasPauseRequest = 0;
+    uint8_t paused = 0;
+    uint8_t hasPauseState = 0;
+};
+
+FastNetMessageNative ExtractFastFields(NetMessageDirection direction, int32_t msgId, const CNetMessage *message) {
+    FastNetMessageNative result{};
+    if (!message)
+        return result;
+
+    __try {
+        auto *pb = message->AsMessageLite();
+        if (!pb)
+            return result;
+
+        if (direction == NetMessageDirection::Incoming && msgId == clc_RequestPause) {
+            auto *pause = static_cast<const CCLCMsg_RequestPause *>(pb);
+            result.hasPauseRequest = 1;
+            result.pauseType = pause->has_pause_type() ? static_cast<int32_t>(pause->pause_type()) : static_cast<int32_t>(RP_PAUSE);
+            result.pauseGroup = pause->has_pause_group() ? pause->pause_group() : 0;
+            return result;
+        }
+
+        if (direction == NetMessageDirection::Outgoing && msgId == svc_SetPause) {
+            auto *pause = static_cast<const CSVCMsg_SetPause *>(pb);
+            result.hasPauseState = 1;
+            result.paused = pause->has_paused() && pause->paused() ? 1 : 0;
+            return result;
+        }
+
+        if (direction == NetMessageDirection::Outgoing && msgId == svc_UserMessage) {
+            auto *user = static_cast<const CSVCMsg_UserMessage *>(pb);
+            if (user->has_msg_type()) {
+                result.hasUserMessageType = 1;
+                result.userMessageType = user->msg_type();
+            }
+            return result;
+        }
+    } __except (EXCEPTION_EXECUTE_HANDLER) {
+        g_directExceptions.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    return result;
+}
+
+} // namespace
+
+void SetNetMessageSerializedInterest(NetMessageDirection direction, int32_t msgId, bool enabled) {
+    SetMessageInterest(TableFor(direction, true), msgId, enabled);
+}
+
+void SetNetMessageFastInterest(NetMessageDirection direction, int32_t msgId, bool enabled) {
+    SetMessageInterest(TableFor(direction, false), msgId, enabled);
+}
+
+void SetUserMessageSerializedInterest(int32_t userMessageType, bool enabled) {
+    SetUserMessageInterest(g_serializedUserMessages, g_serializedUserMessageInterestCount, userMessageType, enabled);
+}
+
+void SetUserMessageFastInterest(int32_t userMessageType, bool enabled) {
+    SetUserMessageInterest(g_fastUserMessages, g_fastUserMessageInterestCount, userMessageType, enabled);
+}
+
+bool HasNetMessageSerializedInterest(NetMessageDirection direction, int32_t msgId) {
+    if (!IsValidMessageId(msgId))
+        return false;
+    return TableFor(direction, true)[static_cast<size_t>(msgId)].load(std::memory_order_relaxed) != 0;
+}
+
+bool HasNetMessageFastInterest(NetMessageDirection direction, int32_t msgId) {
+    if (!IsValidMessageId(msgId))
+        return false;
+    return TableFor(direction, false)[static_cast<size_t>(msgId)].load(std::memory_order_relaxed) != 0;
+}
+
+bool HasAnyUserMessageSerializedInterest() {
+    return g_serializedUserMessageInterestCount.load(std::memory_order_relaxed) != 0;
+}
+
+bool HasUserMessageSerializedInterest(int32_t userMessageType) {
+    if (!IsValidUserMessageType(userMessageType))
+        return false;
+    return g_serializedUserMessages[static_cast<size_t>(userMessageType)].load(std::memory_order_relaxed) != 0;
+}
+
+bool HasUserMessageFastInterest(int32_t userMessageType) {
+    if (!IsValidUserMessageType(userMessageType))
+        return false;
+    return g_fastUserMessages[static_cast<size_t>(userMessageType)].load(std::memory_order_relaxed) != 0;
+}
+
+void ProcessFastNetMessage(NetMessageDirection direction, int32_t endpointSlot, int32_t msgId,
+                           const CNetMessage *message, uint64_t recipientMask) {
+    const bool probeEnabled = ProbeLogEnabled();
+    if (!probeEnabled && !HasAnyInterest())
+        return;
+
+    if (probeEnabled) {
+        if (direction == NetMessageDirection::Incoming)
+            g_incomingSeen.fetch_add(1, std::memory_order_relaxed);
+        else
+            g_outgoingSeen.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    const bool hasMessageSerialized = HasNetMessageSerializedInterest(direction, msgId);
+    const bool hasMessageFast = HasNetMessageFastInterest(direction, msgId);
+
+    bool extracted = false;
+    bool hasUserMessageSerialized = false;
+    bool hasUserMessageFast = false;
+    FastNetMessageNative fields{};
+
+    if (direction == NetMessageDirection::Outgoing &&
+        (HasAnyUserMessageSerializedInterest() || HasAnyUserMessageFastInterest())) {
+        if (msgId == svc_UserMessage) {
+            fields = ExtractFastFields(direction, msgId, message);
+            extracted = true;
+            hasUserMessageSerialized = fields.hasUserMessageType && HasUserMessageSerializedInterest(fields.userMessageType);
+            hasUserMessageFast = fields.hasUserMessageType && HasUserMessageFastInterest(fields.userMessageType);
+        } else {
+            hasUserMessageSerialized = HasUserMessageSerializedInterest(msgId);
+            hasUserMessageFast = HasUserMessageFastInterest(msgId);
+            if (hasUserMessageSerialized || hasUserMessageFast) {
+                fields.hasUserMessageType = 1;
+                fields.userMessageType = msgId;
+            }
+        }
+    }
+
+    const bool hasSerialized = hasMessageSerialized || hasUserMessageSerialized;
+    const bool hasFast = hasMessageFast || hasUserMessageFast;
+
+    if (!hasSerialized && !hasFast) {
+        if (probeEnabled) {
+            if (direction == NetMessageDirection::Incoming)
+                g_noInterestIncoming.fetch_add(1, std::memory_order_relaxed);
+            else
+                g_noInterestOutgoing.fetch_add(1, std::memory_order_relaxed);
+        }
+        return;
+    }
+
+    if (probeEnabled && hasSerialized) {
+        if (direction == NetMessageDirection::Incoming)
+            g_serializedIncomingHits.fetch_add(1, std::memory_order_relaxed);
+        else
+            g_serializedOutgoingHits.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    if (!hasFast || !g_Deadworks.HasFastNetMessageCallback())
+        return;
+
+    if (!extracted)
+        fields = ExtractFastFields(direction, msgId, message);
+
+    g_Deadworks.OnFastNetMessage(static_cast<int32_t>(direction), endpointSlot, msgId, recipientMask,
+                                 fields.userMessageType, fields.hasUserMessageType,
+                                 fields.pauseType, fields.pauseGroup, fields.hasPauseRequest,
+                                 fields.paused, fields.hasPauseState);
+
+    if (probeEnabled) {
+        if (direction == NetMessageDirection::Incoming)
+            g_fastIncomingCallbacks.fetch_add(1, std::memory_order_relaxed);
+        else
+            g_fastOutgoingCallbacks.fetch_add(1, std::memory_order_relaxed);
+        if (hasUserMessageFast)
+            g_fastUserMessageCallbacks.fetch_add(1, std::memory_order_relaxed);
+    }
+}
+
+void LogNetMessageVisitorStatsIfDue() {
+    if (!ProbeLogEnabled())
+        return;
+
+    auto now = std::chrono::steady_clock::now();
+    if (g_lastProbeLog.time_since_epoch().count() != 0 &&
+        std::chrono::duration_cast<std::chrono::milliseconds>(now - g_lastProbeLog).count() < ProbeWindowMs()) {
+        return;
+    }
+    g_lastProbeLog = now;
+
+    g_Log->Info("[NetMessageVisitor] incomingSeen={} outgoingSeen={} serializedIncomingHits={} serializedOutgoingHits={} fastIncomingCallbacks={} fastOutgoingCallbacks={} fastUserMessageCallbacks={} noInterestIncoming={} noInterestOutgoing={} directExceptions={}",
+                g_incomingSeen.load(std::memory_order_relaxed),
+                g_outgoingSeen.load(std::memory_order_relaxed),
+                g_serializedIncomingHits.load(std::memory_order_relaxed),
+                g_serializedOutgoingHits.load(std::memory_order_relaxed),
+                g_fastIncomingCallbacks.load(std::memory_order_relaxed),
+                g_fastOutgoingCallbacks.load(std::memory_order_relaxed),
+                g_fastUserMessageCallbacks.load(std::memory_order_relaxed),
+                g_noInterestIncoming.load(std::memory_order_relaxed),
+                g_noInterestOutgoing.load(std::memory_order_relaxed),
+                g_directExceptions.load(std::memory_order_relaxed));
+}
+
+} // namespace deadworks

--- a/deadworks/src/Core/NetMessageVisitorRuntime.hpp
+++ b/deadworks/src/Core/NetMessageVisitorRuntime.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdint>
+
+class CNetMessage;
+
+namespace deadworks {
+
+enum class NetMessageDirection : int32_t {
+    Incoming = 0,
+    Outgoing = 1,
+};
+
+void SetNetMessageSerializedInterest(NetMessageDirection direction, int32_t msgId, bool enabled);
+void SetNetMessageFastInterest(NetMessageDirection direction, int32_t msgId, bool enabled);
+void SetUserMessageSerializedInterest(int32_t userMessageType, bool enabled);
+void SetUserMessageFastInterest(int32_t userMessageType, bool enabled);
+bool HasNetMessageSerializedInterest(NetMessageDirection direction, int32_t msgId);
+bool HasNetMessageFastInterest(NetMessageDirection direction, int32_t msgId);
+bool HasAnyUserMessageSerializedInterest();
+bool HasUserMessageSerializedInterest(int32_t userMessageType);
+bool HasUserMessageFastInterest(int32_t userMessageType);
+
+void ProcessFastNetMessage(NetMessageDirection direction, int32_t endpointSlot, int32_t msgId,
+                           const CNetMessage *message, uint64_t recipientMask);
+
+void LogNetMessageVisitorStatsIfDue();
+
+} // namespace deadworks

--- a/deadworks/src/Core/UsercmdVisitorRuntime.cpp
+++ b/deadworks/src/Core/UsercmdVisitorRuntime.cpp
@@ -1,0 +1,594 @@
+#include "UsercmdVisitorRuntime.hpp"
+
+#include "Deadworks.hpp"
+#include "ManagedCallbacks.hpp"
+
+#include <google/protobuf/message_lite.h>
+
+#include <atomic>
+#include <cstdlib>
+#include <cstring>
+#include <string_view>
+
+namespace deadworks {
+namespace hooks {
+
+namespace {
+
+// CUserCmd layout observed from Deadlock dedicated-server ProcessUsercmds input:
+// 0x00: vtable ptr (CUserCmdBase/CUserCmd)
+// 0x08: command tick/state
+// 0x10: embedded CCitadelUserCmdPB (MessageLite-derived through CUserCmdBaseHost)
+// Total stride: 0xA8 (168 bytes)
+constexpr size_t kCUserCmdStride = 0xA8;
+constexpr size_t kProtobufOffset = 0x10;
+
+// Direct-read offsets in the generated protobuf object layout used by the server build.
+// Reads are has-bit and pointer guarded, wrapped in SEH, and treated as read-only telemetry.
+constexpr size_t kProtoHasBitsOffset = 0x10;
+constexpr size_t kCitadelBasePtrOffset = 0x38;
+constexpr uint32_t kCitadelHasBaseMask = 0x00000001u;
+constexpr size_t kBaseButtonsPtrOffset = 0x38;
+constexpr size_t kBaseViewAnglesPtrOffset = 0x40;
+constexpr size_t kBaseClientTickOffset = 0x54;
+constexpr size_t kBaseForwardMoveOffset = 0x58;
+constexpr size_t kBaseLeftMoveOffset = 0x5C;
+constexpr uint32_t kBaseHasButtonsMask = 0x00000002u;
+constexpr uint32_t kBaseHasViewAnglesMask = 0x00000004u;
+constexpr size_t kButtonsState1Offset = 0x18;
+constexpr size_t kQAnglePitchOffset = 0x18;
+constexpr size_t kQAngleYawOffset = 0x1C;
+constexpr size_t kQAngleRollOffset = 0x20;
+
+static_assert(sizeof(FastUsercmdNative) == 48, "FastUsercmdNative ABI must match managed FastUsercmd");
+
+static bool TextEquals(std::string_view left, std::string_view right) {
+    return left == right;
+}
+
+static bool EnvEnabled(const char *name) {
+    const char *value = std::getenv(name);
+    if (!value || !*value)
+        return false;
+    return std::strcmp(value, "0") != 0 && _stricmp(value, "false") != 0 && _stricmp(value, "off") != 0;
+}
+
+static uint64_t EnvUint64(const char *name, uint64_t fallback, int base = 10) {
+    const char *value = std::getenv(name);
+    if (!value || !*value)
+        return fallback;
+    char *end = nullptr;
+    auto parsed = std::strtoull(value, &end, base);
+    return end == value ? fallback : parsed;
+}
+
+static UsercmdNativeMode ParseUsercmdMode(const char *value) {
+    if (!value || !*value)
+        return UsercmdNativeMode::MountedPolicy;
+
+    std::string_view mode(value);
+    if (TextEquals(mode, "off") || TextEquals(mode, "disabled") || TextEquals(mode, "0"))
+        return UsercmdNativeMode::Off;
+    if (TextEquals(mode, "count") || TextEquals(mode, "counter") || TextEquals(mode, "count-only") || TextEquals(mode, "1"))
+        return UsercmdNativeMode::CountOnly;
+    if (TextEquals(mode, "direct") || TextEquals(mode, "sample") || TextEquals(mode, "direct-sample") || TextEquals(mode, "2") || TextEquals(mode, "3"))
+        return UsercmdNativeMode::DirectSample;
+    if (TextEquals(mode, "fast") || TextEquals(mode, "typed") || TextEquals(mode, "fast-read") || TextEquals(mode, "direct-dispatch") || TextEquals(mode, "4"))
+        return UsercmdNativeMode::FastDispatch;
+    if (TextEquals(mode, "mounted") || TextEquals(mode, "policy") || TextEquals(mode, "auto") || TextEquals(mode, "5"))
+        return UsercmdNativeMode::MountedPolicy;
+    if (TextEquals(mode, "serialize") || TextEquals(mode, "protobuf") || TextEquals(mode, "managed") || TextEquals(mode, "default-deadworks"))
+        return UsercmdNativeMode::SerializeManaged;
+
+    return UsercmdNativeMode::MountedPolicy;
+}
+
+static uint32_t ParseMountMaskEnv() {
+    const char *value = std::getenv("DEADWORKS_USERCMD_MOUNT_MASK");
+    if (!value || !*value)
+        value = std::getenv("DEADWORKS_USERCMD_MOUNTS");
+    if (!value || !*value)
+        return UsercmdMountNone;
+
+    std::string_view text(value);
+    if (TextEquals(text, "all") || TextEquals(text, "ALL"))
+        return UsercmdMountAll;
+
+    uint32_t mask = UsercmdMountNone;
+    if (text.find("full") != std::string_view::npos || text.find("protobuf") != std::string_view::npos)
+        mask |= UsercmdMountFullProtobuf;
+    if (text.find("fast") != std::string_view::npos || text.find("typed") != std::string_view::npos)
+        mask |= UsercmdMountFastRead;
+    if (text.find("trigger") != std::string_view::npos || text.find("button") != std::string_view::npos)
+        mask |= UsercmdMountButtonTriggers;
+    if (mask != UsercmdMountNone)
+        return mask;
+
+    return static_cast<uint32_t>(std::strtoul(value, nullptr, 0)) & UsercmdMountAll;
+}
+
+static uint64_t ParseButtonTriggerMaskEnv() {
+    const char *value = std::getenv("DEADWORKS_USERCMD_BUTTON_TRIGGER_MASK");
+    if (!value || !*value)
+        return 0;
+    if (_stricmp(value, "all") == 0)
+        return UINT64_MAX;
+    return static_cast<uint64_t>(std::strtoull(value, nullptr, 0));
+}
+
+static uint32_t ParseFieldMaskEnv() {
+    const char *value = std::getenv("DEADWORKS_USERCMD_FIELD_MASK");
+    if (!value || !*value)
+        value = std::getenv("DEADWORKS_USERCMD_FIELDS");
+    if (!value || !*value)
+        return UsercmdFieldAll;
+
+    std::string_view text(value);
+    if (TextEquals(text, "all") || TextEquals(text, "ALL"))
+        return UsercmdFieldAll;
+
+    uint32_t mask = UsercmdFieldNone;
+    if (text.find("tick") != std::string_view::npos)
+        mask |= UsercmdFieldClientTick;
+    if (text.find("button") != std::string_view::npos)
+        mask |= UsercmdFieldButtons;
+    if (text.find("view") != std::string_view::npos || text.find("angle") != std::string_view::npos)
+        mask |= UsercmdFieldViewAngles;
+    if (text.find("move") != std::string_view::npos || text.find("movement") != std::string_view::npos)
+        mask |= UsercmdFieldMovement;
+    if (mask != UsercmdFieldNone)
+        return mask;
+
+    return static_cast<uint32_t>(std::strtoul(value, nullptr, 0)) & UsercmdFieldAll;
+}
+
+static bool ShouldLog() {
+    return EnvEnabled("DEADWORKS_USERCMD_PROBE_LOG") || EnvEnabled("DEADWORKS_USERCMD_PROBE_LOGGING");
+}
+
+static uint64_t LogWindowMs() {
+    return EnvUint64("DEADWORKS_USERCMD_PROBE_LOG_WINDOW_MS", EnvUint64("DEADWORKS_USERCMD_PROBE_LOG_MS", 5000));
+}
+
+static std::atomic<int32_t> g_ModeOverride{static_cast<int32_t>(UsercmdNativeMode::DefaultFromEnvironment)};
+static std::atomic<uint32_t> g_MountMask{ParseMountMaskEnv()};
+static std::atomic<uint64_t> g_ButtonTriggerMask{ParseButtonTriggerMaskEnv()};
+static std::atomic<uint32_t> g_FieldMask{ParseFieldMaskEnv()};
+static uint64_t g_LastButtonsBySlot[64]{};
+static LARGE_INTEGER g_PerfFrequency{};
+
+struct UsercmdCounters {
+    uint64_t batches = 0;
+    uint64_t cmds = 0;
+    uint64_t serializedCmds = 0;
+    uint64_t serializedBytes = 0;
+    uint64_t serializeTicks = 0;
+    uint64_t managedTicks = 0;
+    uint64_t directCmds = 0;
+    uint64_t directBase = 0;
+    uint64_t directButtons = 0;
+    uint64_t directAngles = 0;
+    uint64_t directExceptions = 0;
+    uint64_t directTicks = 0;
+    uint64_t directReadOps = 0;
+    uint64_t serializeOps = 0;
+    uint64_t parseOps = 0;
+    uint64_t managedCallbacks = 0;
+    uint64_t triggerCallbacks = 0;
+    int32_t lastClientTick = 0;
+    uint64_t lastButtons = 0;
+    float lastPitch = 0.0f;
+    float lastYaw = 0.0f;
+    float lastForward = 0.0f;
+    float lastLeft = 0.0f;
+    uint64_t lastLogMs = 0;
+};
+
+static UsercmdCounters g_Counters[64]{};
+
+static uint64_t QpcNow() {
+    LARGE_INTEGER value{};
+    QueryPerformanceCounter(&value);
+    return static_cast<uint64_t>(value.QuadPart);
+}
+
+static uint64_t QpcToMicros(uint64_t ticks) {
+    if (!g_PerfFrequency.QuadPart)
+        QueryPerformanceFrequency(&g_PerfFrequency);
+    return static_cast<uint64_t>((ticks * 1000000ULL) / static_cast<uint64_t>(g_PerfFrequency.QuadPart));
+}
+
+struct DirectReadResult {
+    int directCmds = 0;
+    int base = 0;
+    int buttons = 0;
+    int angles = 0;
+    int exceptions = 0;
+    uint64_t ticks = 0;
+    uint64_t readOps = 0;
+    int32_t lastClientTick = 0;
+    uint64_t lastButtons = 0;
+    float lastPitch = 0.0f;
+    float lastYaw = 0.0f;
+    float lastForward = 0.0f;
+    float lastLeft = 0.0f;
+};
+
+static UsercmdNativeMode EffectiveMode() {
+    int32_t overrideMode = g_ModeOverride.load(std::memory_order_relaxed);
+    if (overrideMode >= 0)
+        return static_cast<UsercmdNativeMode>(overrideMode);
+
+    static UsercmdNativeMode mode = [] {
+        if (const char *disabled = std::getenv("DEADWORKS_DISABLE_USERCMDS"); disabled && std::string_view(disabled) == "1")
+            return UsercmdNativeMode::Off;
+        return ParseUsercmdMode(std::getenv("DEADWORKS_USERCMD_NATIVE_MODE"));
+    }();
+    return mode;
+}
+
+static DirectReadResult ExtractFastFields(void *cmds, int numcmds, uint32_t requestedFields, std::vector<FastUsercmdNative> *out) {
+    DirectReadResult result{};
+    requestedFields &= UsercmdFieldAll;
+    if (requestedFields == UsercmdFieldNone)
+        requestedFields = UsercmdFieldAll;
+    if (out) {
+        out->clear();
+        out->reserve(static_cast<size_t>(numcmds));
+    }
+
+    uint64_t start = QpcNow();
+    for (int i = 0; i < numcmds; i++) {
+        FastUsercmdNative item{};
+        item.commandIndex = i;
+
+        __try {
+            auto *cmdBase = reinterpret_cast<uint8_t *>(cmds) + (i * kCUserCmdStride);
+            auto *citadel = cmdBase + kProtobufOffset;
+            uint32_t citadelHas = *reinterpret_cast<uint32_t *>(citadel + kProtoHasBitsOffset);
+            result.readOps++;
+            result.directCmds++;
+
+            if (citadelHas & kCitadelHasBaseMask) {
+                auto *base = *reinterpret_cast<uint8_t **>(citadel + kCitadelBasePtrOffset);
+                result.readOps++;
+                if (base) {
+                    item.hasBase = 1;
+                    result.base++;
+
+                    uint32_t baseHas = *reinterpret_cast<uint32_t *>(base + kProtoHasBitsOffset);
+                    result.readOps++;
+
+                    if (requestedFields & UsercmdFieldClientTick) {
+                        item.clientTick = *reinterpret_cast<int32_t *>(base + kBaseClientTickOffset);
+                        result.readOps++;
+                    }
+
+                    if (requestedFields & UsercmdFieldMovement) {
+                        item.forwardMove = *reinterpret_cast<float *>(base + kBaseForwardMoveOffset);
+                        item.leftMove = *reinterpret_cast<float *>(base + kBaseLeftMoveOffset);
+                        result.readOps += 2;
+                    }
+
+                    if ((requestedFields & UsercmdFieldButtons) && (baseHas & kBaseHasButtonsMask)) {
+                        auto *buttons = *reinterpret_cast<uint8_t **>(base + kBaseButtonsPtrOffset);
+                        result.readOps++;
+                        if (buttons) {
+                            item.hasButtons = 1;
+                            item.buttons = *reinterpret_cast<uint64_t *>(buttons + kButtonsState1Offset);
+                            result.readOps++;
+                            result.buttons++;
+                        }
+                    }
+
+                    if ((requestedFields & UsercmdFieldViewAngles) && (baseHas & kBaseHasViewAnglesMask)) {
+                        auto *angles = *reinterpret_cast<uint8_t **>(base + kBaseViewAnglesPtrOffset);
+                        result.readOps++;
+                        if (angles) {
+                            item.hasViewAngles = 1;
+                            item.pitch = *reinterpret_cast<float *>(angles + kQAnglePitchOffset);
+                            item.yaw = *reinterpret_cast<float *>(angles + kQAngleYawOffset);
+                            item.roll = *reinterpret_cast<float *>(angles + kQAngleRollOffset);
+                            result.readOps += 3;
+                            result.angles++;
+                        }
+                    }
+                }
+            }
+
+            result.lastClientTick = item.clientTick;
+            result.lastButtons = item.buttons;
+            result.lastPitch = item.pitch;
+            result.lastYaw = item.yaw;
+            result.lastForward = item.forwardMove;
+            result.lastLeft = item.leftMove;
+            if (out)
+                out->push_back(item);
+        } __except (EXCEPTION_EXECUTE_HANDLER) {
+            result.exceptions++;
+        }
+    }
+
+    result.ticks = QpcNow() - start;
+    return result;
+}
+
+struct FullDispatchResult {
+    int serializedCmds = 0;
+    int serializedBytes = 0;
+    uint64_t serializeTicks = 0;
+    uint64_t managedTicks = 0;
+    uint64_t serializeOps = 0;
+    uint64_t parseOps = 0;
+    uint64_t managedCallbacks = 0;
+};
+
+static FullDispatchResult DispatchFullProtobuf(int slot, void *cmds, int numcmds, unsigned char paused, float margin) {
+    FullDispatchResult result{};
+    uint64_t serializeStart = QpcNow();
+
+    static thread_local std::vector<uint8_t> batchBuf;
+    batchBuf.clear();
+
+    static thread_local std::vector<int> validCmdIndices;
+    validCmdIndices.clear();
+
+    for (int i = 0; i < numcmds; i++) {
+        auto *cmdBase = reinterpret_cast<char *>(cmds) + (i * kCUserCmdStride);
+        auto *pb = reinterpret_cast<google::protobuf::MessageLite *>(cmdBase + kProtobufOffset);
+
+        result.serializeOps++;
+        int size = static_cast<int>(pb->ByteSizeLong());
+        if (size <= 0)
+            continue;
+
+        size_t offset = batchBuf.size();
+        batchBuf.resize(offset + 4 + size);
+        std::memcpy(batchBuf.data() + offset, &size, 4);
+
+        result.serializeOps++;
+        if (!pb->SerializeToArray(batchBuf.data() + offset + 4, size)) {
+            batchBuf.resize(offset);
+            continue;
+        }
+
+        validCmdIndices.push_back(i);
+    }
+
+    result.serializeTicks = QpcNow() - serializeStart;
+    result.serializedCmds = static_cast<int>(validCmdIndices.size());
+    result.serializedBytes = static_cast<int>(batchBuf.size());
+
+    if (!validCmdIndices.empty()) {
+        static thread_local uint8_t outBuf[65536];
+        int outLen = 0;
+
+        uint64_t managedStart = QpcNow();
+        g_Deadworks.OnPre_ProcessUsercmds(slot, batchBuf.data(),
+                                           static_cast<int>(batchBuf.size()),
+                                           static_cast<int>(validCmdIndices.size()),
+                                           paused != 0, margin,
+                                           outBuf, &outLen);
+        result.managedTicks = QpcNow() - managedStart;
+        result.managedCallbacks++;
+
+        if (outLen > 0) {
+            int offset = 0;
+            for (size_t idx = 0; idx < validCmdIndices.size() && offset + 4 <= outLen; idx++) {
+                int len = 0;
+                std::memcpy(&len, outBuf + offset, 4);
+                offset += 4;
+
+                if (len <= 0 || offset + len > outLen)
+                    break;
+
+                auto *cmdBase = reinterpret_cast<char *>(cmds) + (validCmdIndices[idx] * kCUserCmdStride);
+                auto *pb = reinterpret_cast<google::protobuf::MessageLite *>(cmdBase + kProtobufOffset);
+                pb->ParseFromArray(outBuf + offset, len);
+                result.parseOps++;
+
+                offset += len;
+            }
+        }
+    }
+
+    return result;
+}
+
+static uint64_t DispatchButtonTriggers(int slot, const std::vector<FastUsercmdNative> &fastCmds, unsigned char paused, float margin) {
+    uint64_t triggerMask = GetUsercmdButtonTriggerMask();
+    if (slot < 0 || slot >= 64 || triggerMask == 0 || fastCmds.empty())
+        return 0;
+
+    uint64_t callbacks = 0;
+    uint64_t lastButtons = g_LastButtonsBySlot[slot];
+    for (const auto &cmd : fastCmds) {
+        if (!cmd.hasButtons)
+            continue;
+
+        uint64_t pressed = cmd.buttons & ~lastButtons;
+        uint64_t triggered = pressed & triggerMask;
+        lastButtons = cmd.buttons;
+
+        if (!triggered)
+            continue;
+
+        g_Deadworks.OnUsercmdTrigger(slot, &cmd, pressed, triggered, paused != 0, margin);
+        callbacks++;
+    }
+
+    g_LastButtonsBySlot[slot] = lastButtons;
+    return callbacks;
+}
+
+static void Accumulate(int slot, int numcmds, const FullDispatchResult &full,
+                       const DirectReadResult *direct, uint64_t managedTicksOverride = 0,
+                       uint64_t managedCallbacksOverride = 0, uint64_t triggerCallbacks = 0) {
+    if (slot < 0 || slot >= 64)
+        return;
+
+    auto &c = g_Counters[slot];
+    c.batches++;
+    c.cmds += static_cast<uint64_t>(numcmds > 0 ? numcmds : 0);
+    c.serializedCmds += static_cast<uint64_t>(full.serializedCmds > 0 ? full.serializedCmds : 0);
+    c.serializedBytes += static_cast<uint64_t>(full.serializedBytes > 0 ? full.serializedBytes : 0);
+    c.serializeTicks += full.serializeTicks;
+    c.managedTicks += full.managedTicks + managedTicksOverride;
+    c.serializeOps += full.serializeOps;
+    c.parseOps += full.parseOps;
+    c.managedCallbacks += full.managedCallbacks + managedCallbacksOverride;
+    c.triggerCallbacks += triggerCallbacks;
+
+    if (direct) {
+        c.directCmds += static_cast<uint64_t>(direct->directCmds);
+        c.directBase += static_cast<uint64_t>(direct->base);
+        c.directButtons += static_cast<uint64_t>(direct->buttons);
+        c.directAngles += static_cast<uint64_t>(direct->angles);
+        c.directExceptions += static_cast<uint64_t>(direct->exceptions);
+        c.directTicks += direct->ticks;
+        c.directReadOps += direct->readOps;
+        c.lastClientTick = direct->lastClientTick;
+        c.lastButtons = direct->lastButtons;
+        c.lastPitch = direct->lastPitch;
+        c.lastYaw = direct->lastYaw;
+        c.lastForward = direct->lastForward;
+        c.lastLeft = direct->lastLeft;
+    }
+
+    if (!ShouldLog())
+        return;
+
+    uint64_t now = GetTickCount64();
+    uint64_t windowMs = LogWindowMs();
+    if (windowMs > 0 && now - c.lastLogMs >= windowMs) {
+        c.lastLogMs = now;
+        g_Log->Info("[UsercmdVisitor] slot={} batches={} cmds={} serializedCmds={} serializedBytes={} serializeUs={} managedUs={} mode={} mountMask=0x{:X} directCmds={} directBase={} directButtons={} directAngles={} directExceptions={} directUs={} directReadOps={} serializeOps={} parseOps={} managedCallbacks={} triggerCallbacks={} lastClientTick={} lastButtons=0x{:X} lastPitch={} lastYaw={} lastForward={} lastLeft={}",
+                    slot, c.batches, c.cmds, c.serializedCmds, c.serializedBytes,
+                    QpcToMicros(c.serializeTicks), QpcToMicros(c.managedTicks), static_cast<int>(EffectiveMode()), GetUsercmdMountMask(),
+                    c.directCmds, c.directBase, c.directButtons, c.directAngles, c.directExceptions,
+                    QpcToMicros(c.directTicks), c.directReadOps, c.serializeOps, c.parseOps,
+                    c.managedCallbacks, c.triggerCallbacks,
+                    c.lastClientTick, c.lastButtons, c.lastPitch, c.lastYaw, c.lastForward, c.lastLeft);
+    }
+}
+
+} // namespace
+
+void SetUsercmdNativeMode(int32_t mode) {
+    if (mode < static_cast<int32_t>(UsercmdNativeMode::DefaultFromEnvironment) ||
+        mode > static_cast<int32_t>(UsercmdNativeMode::MountedPolicy)) {
+        mode = static_cast<int32_t>(UsercmdNativeMode::DefaultFromEnvironment);
+    }
+    g_ModeOverride.store(mode, std::memory_order_relaxed);
+}
+
+int32_t GetUsercmdNativeMode() {
+    return static_cast<int32_t>(EffectiveMode());
+}
+
+void SetUsercmdMountMask(uint32_t mask) {
+    g_MountMask.store(mask & UsercmdMountAll, std::memory_order_relaxed);
+}
+
+uint32_t GetUsercmdMountMask() {
+    return g_MountMask.load(std::memory_order_relaxed);
+}
+
+void SetUsercmdButtonTriggerMask(uint64_t mask) {
+    g_ButtonTriggerMask.store(mask, std::memory_order_relaxed);
+}
+
+uint64_t GetUsercmdButtonTriggerMask() {
+    return g_ButtonTriggerMask.load(std::memory_order_relaxed);
+}
+
+void SetUsercmdFieldMask(uint32_t mask) {
+    g_FieldMask.store(mask & UsercmdFieldAll, std::memory_order_relaxed);
+}
+
+uint32_t GetUsercmdFieldMask() {
+    auto mask = g_FieldMask.load(std::memory_order_relaxed) & UsercmdFieldAll;
+    return mask == UsercmdFieldNone ? UsercmdFieldAll : mask;
+}
+
+void ProcessUsercmdVisitors(int slot, void *cmds, int numcmds, unsigned char paused, float margin) {
+    if (slot < 0 || slot >= 64 || numcmds <= 0)
+        return;
+
+    auto mode = EffectiveMode();
+    FullDispatchResult emptyFull{};
+
+    if (mode == UsercmdNativeMode::Off || mode == UsercmdNativeMode::CountOnly) {
+        Accumulate(slot, numcmds, emptyFull, nullptr);
+        return;
+    }
+
+    if (mode == UsercmdNativeMode::DirectSample) {
+        auto direct = ExtractFastFields(cmds, numcmds, GetUsercmdFieldMask(), nullptr);
+        Accumulate(slot, numcmds, emptyFull, &direct);
+        return;
+    }
+
+    if (mode == UsercmdNativeMode::FastDispatch) {
+        static thread_local std::vector<FastUsercmdNative> fastCmds;
+        auto direct = ExtractFastFields(cmds, numcmds, GetUsercmdFieldMask(), &fastCmds);
+        uint64_t managedTicks = 0;
+        uint64_t managedCallbacks = 0;
+        if (!fastCmds.empty()) {
+            uint64_t managedStart = QpcNow();
+            g_Deadworks.OnFast_ProcessUsercmds(slot, fastCmds.data(), static_cast<int>(fastCmds.size()), paused != 0, margin);
+            managedTicks = QpcNow() - managedStart;
+            managedCallbacks = 1;
+        }
+        Accumulate(slot, numcmds, emptyFull, &direct, managedTicks, managedCallbacks);
+        return;
+    }
+
+    if (mode == UsercmdNativeMode::MountedPolicy) {
+        uint32_t mountMask = GetUsercmdMountMask();
+        if (mountMask == UsercmdMountNone) {
+            Accumulate(slot, numcmds, emptyFull, nullptr);
+            return;
+        }
+
+        DirectReadResult direct{};
+        const DirectReadResult *directPtr = nullptr;
+        uint64_t managedTicks = 0;
+        uint64_t managedCallbacks = 0;
+        uint64_t triggerCallbacks = 0;
+        static thread_local std::vector<FastUsercmdNative> fastCmds;
+
+        const bool needDirect = (mountMask & UsercmdMountFastRead) != 0 ||
+                                ((mountMask & UsercmdMountButtonTriggers) != 0 && GetUsercmdButtonTriggerMask() != 0);
+        if (needDirect) {
+            uint32_t requestedFields = GetUsercmdFieldMask();
+            if ((mountMask & UsercmdMountButtonTriggers) && GetUsercmdButtonTriggerMask() != 0)
+                requestedFields |= UsercmdFieldButtons;
+            direct = ExtractFastFields(cmds, numcmds, requestedFields, &fastCmds);
+            directPtr = &direct;
+
+            if ((mountMask & UsercmdMountButtonTriggers) && GetUsercmdButtonTriggerMask() != 0)
+                triggerCallbacks = DispatchButtonTriggers(slot, fastCmds, paused, margin);
+
+            if ((mountMask & UsercmdMountFastRead) && !fastCmds.empty()) {
+                uint64_t managedStart = QpcNow();
+                g_Deadworks.OnFast_ProcessUsercmds(slot, fastCmds.data(), static_cast<int>(fastCmds.size()), paused != 0, margin);
+                managedTicks += QpcNow() - managedStart;
+                managedCallbacks++;
+            }
+        }
+
+        FullDispatchResult full{};
+        if (mountMask & UsercmdMountFullProtobuf)
+            full = DispatchFullProtobuf(slot, cmds, numcmds, paused, margin);
+
+        Accumulate(slot, numcmds, full, directPtr, managedTicks, managedCallbacks, triggerCallbacks);
+        return;
+    }
+
+    auto full = DispatchFullProtobuf(slot, cmds, numcmds, paused, margin);
+    Accumulate(slot, numcmds, full, nullptr);
+}
+
+} // namespace hooks
+} // namespace deadworks

--- a/deadworks/src/Core/UsercmdVisitorRuntime.hpp
+++ b/deadworks/src/Core/UsercmdVisitorRuntime.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstdint>
+
+namespace deadworks {
+namespace hooks {
+
+enum class UsercmdNativeMode : int32_t {
+    DefaultFromEnvironment = -1,
+    SerializeManaged = 0,
+    Off = 1,
+    CountOnly = 2,
+    DirectSample = 3,
+    FastDispatch = 4,
+    MountedPolicy = 5,
+};
+
+enum UsercmdMountFlags : uint32_t {
+    UsercmdMountNone = 0,
+    UsercmdMountFullProtobuf = 1u << 0,
+    UsercmdMountFastRead = 1u << 1,
+    UsercmdMountButtonTriggers = 1u << 2,
+    UsercmdMountAll = UsercmdMountFullProtobuf | UsercmdMountFastRead | UsercmdMountButtonTriggers,
+};
+
+enum UsercmdFieldFlags : uint32_t {
+    UsercmdFieldNone = 0,
+    UsercmdFieldClientTick = 1u << 0,
+    UsercmdFieldButtons = 1u << 1,
+    UsercmdFieldViewAngles = 1u << 2,
+    UsercmdFieldMovement = 1u << 3,
+    UsercmdFieldAll = UsercmdFieldClientTick | UsercmdFieldButtons | UsercmdFieldViewAngles | UsercmdFieldMovement,
+};
+
+void ProcessUsercmdVisitors(int slot, void *cmds, int numcmds, unsigned char paused, float margin);
+
+void SetUsercmdNativeMode(int32_t mode);
+int32_t GetUsercmdNativeMode();
+
+void SetUsercmdMountMask(uint32_t mask);
+uint32_t GetUsercmdMountMask();
+
+void SetUsercmdButtonTriggerMask(uint64_t mask);
+uint64_t GetUsercmdButtonTriggerMask();
+
+void SetUsercmdFieldMask(uint32_t mask);
+uint32_t GetUsercmdFieldMask();
+
+} // namespace hooks
+} // namespace deadworks

--- a/docs/net-message-visitors.md
+++ b/docs/net-message-visitors.md
@@ -1,0 +1,90 @@
+# Net message visitors
+
+Deadworks now gates protobuf net-message work behind managed interest. The existing full protobuf APIs remain the compatibility/mutation path, while read-only observers can mount compact native visitors for selected message ids.
+
+## Model
+
+The net provider uses Deadworks' existing native hooks:
+
+- incoming client->server messages: `CServerSideClientBase::FilterMessage`
+- outgoing server->client messages: `IGameEventSystem::PostEventAbstract`
+
+On each hook, Deadworks first checks native interest tables. With no serialized or fast interest for the message id, the hook returns without protobuf serialization and without managed dispatch.
+
+There are two separate mounts:
+
+1. **Fast visitor interest** - read-only native extraction for curated fields, dispatched through `OnFastNetMessage(FastNetMessageEvent args)`.
+2. **Serialized interest** - full protobuf compatibility path, mounted automatically when plugins register `NetMessages.HookIncoming<T>()`, `NetMessages.HookOutgoing<T>()`, `[NetMessageHandler]`, chat commands, or `OnChatMessage`.
+
+## Fast visitor API
+
+```csharp
+public override void OnLoad(bool isReload)
+{
+    NetMessages.VisitIncoming((int)CLC_Messages.ClcRequestPause);
+    NetMessages.VisitOutgoing((int)SVC_Messages.SvcSetPause);
+    NetMessages.VisitUserMessage(userMessageType: 123);
+    NetMessages.VisitUserMessage<CCitadelUserMsg_ChatMsg>();
+}
+
+public override void OnFastNetMessage(FastNetMessageEvent args)
+{
+    if (args.HasPauseRequest)
+        Console.WriteLine($"pause request slot={args.EndpointSlot} type={args.PauseType} group={args.PauseGroup}");
+
+    if (args.HasPauseState)
+        Console.WriteLine($"pause state paused={args.Paused}");
+
+    if (args.HasUserMessageType)
+        Console.WriteLine($"user message type={args.UserMessageType} recipients=0x{args.RecipientMask:X}");
+}
+```
+
+Current curated fast fields:
+
+| Message | Direction | Fields |
+|---|---|---|
+| `clc_RequestPause` (`33`) | incoming | `PauseType`, `PauseGroup` |
+| `svc_SetPause` (`43`) | outgoing | `Paused` |
+| `svc_UserMessage` (`72`) | outgoing | nested `UserMessageType` |
+
+`NetMessages.VisitUserMessage(id)` is a second-level interest gate for outgoing user messages. When the engine surfaces the `svc_UserMessage` envelope, Deadworks reads only `msg_type` and calls managed code only when the nested type is mounted; if the hook receives an inner user-message id directly, the same interest table is used.
+
+## Full protobuf compatibility path
+
+Existing APIs still work and now mount serialized interest for only the requested ids. Outgoing user-message protobuf hooks also mount an inner `svc_UserMessage` gate, so the envelope payload is parsed only for matching `msg_type` values:
+
+```csharp
+private IHandle? _hook;
+
+public override void OnLoad(bool isReload)
+{
+    _hook = NetMessages.HookIncoming<CCitadelClientMsg_ChatMsg>(ctx =>
+    {
+        Console.WriteLine(ctx.Message.ChatText);
+        return HookResult.Continue;
+    });
+}
+
+public override void OnUnload()
+{
+    _hook?.Cancel();
+}
+```
+
+Use the full protobuf path when a plugin needs mutation, blocking, recipient-mask changes, or fields not present in `FastNetMessageEvent`.
+
+## Capabilities
+
+```csharp
+if (NativeFeatures.HasCapability("netmsg.interest_gates")) { /* serialized path is gated */ }
+if (NativeFeatures.HasCapability("netmsg.fast_read")) { /* message-id fast visitors */ }
+if (NativeFeatures.HasCapability("netmsg.user_message_interest_gates")) { /* nested full-protobuf user-message gates */ }
+if (NativeFeatures.HasCapability("netmsg.user_message_fast_read")) { /* nested fast svc_UserMessage gate */ }
+```
+
+## Diagnostics
+
+Set `DEADWORKS_NETMSG_PROBE_LOG=1` to emit aggregate counters such as `incomingSeen`, `outgoingSeen`, `serializedIncomingHits`, `fastOutgoingCallbacks`, and `noInterestOutgoing`. `DEADWORKS_NETMSG_PROBE_LOG_WINDOW_MS` controls the log interval.
+
+`examples/plugins/DiagnosticsPlugin` is a deliberately chatty local test plugin that mounts the visitor paths and exposes `/heal N`, `/damage N`, `/teleport`, and `/respawn`.

--- a/docs/usercmd-visitors.md
+++ b/docs/usercmd-visitors.md
@@ -1,0 +1,290 @@
+# Usercmd visitors
+
+This change keeps Deadworks' existing native hook chassis and adds an opt-in visitor surface for hot usercmd telemetry without forcing the full protobuf path.
+
+Although the first provider is usercmd data, the intended pattern is generic: native hook providers expose a small curated set of fields, managed plugins declare interest in those fields, and Deadworks only does the native reads/callbacks required by mounted interests.
+
+## Visitor model
+
+A visitor is an opt-in native data provider for a hot engine path. It has four parts:
+
+1. **Provider hook** - the existing native hook that observes the engine object at the right time. For usercmds this is `CBasePlayerController::ProcessUsercmds`.
+2. **Interest declaration** - managed code or environment configuration requests a mounted feature and, when applicable, a field mask.
+3. **Native field extraction** - native code reads only the requested curated fields into a compact ABI-safe struct.
+4. **Managed dispatch** - managed callbacks receive the compact event without parsing unrelated protobufs or walking arbitrary memory.
+
+The visitor path is intentionally different from arbitrary memory access:
+
+- fields are curated by Deadworks and exposed as named flags;
+- providers should be read-only by default;
+- field reads should be guarded by pointer checks, presence bits when available, and exception boundaries around unsafe memory reads;
+- no mounted interest means the hook should return to the engine with minimal work;
+- full parse/mutation paths remain separate compatibility mounts.
+
+For usercmds, this means `Usercmds.Visit(UsercmdFields.Buttons)` reads buttons but does not read view angles, movement, or serialize `CCitadelUserCmdPB`.
+
+## What Deadworks already hooks
+
+Deadworks already resolves Source 2 interfaces and installs native hooks with SafetyHook and vtable patches. Relevant existing hooks include:
+
+- `CBasePlayerController::ProcessUsercmds` (pre-engine usercmd processing)
+- incoming `CServerSideClientBase::FilterMessage`
+- outgoing `IGameEventSystem::PostEventAbstract`
+- `IGameEventManager2::FireEvent`
+- `ISource2GameEntities::CheckTransmit`
+- client connect/put-in-server/disconnect
+- damage/currency/ability/modifier/entity I/O hooks
+
+So the right place for usercmd memory work is Deadworks' native hook layer, not a second injected shim.
+
+## Usercmd modes
+
+The native `ProcessUsercmds` hook now supports these modes:
+
+| Mode | Value | Behavior |
+|---|---:|---|
+| `DefaultFromEnvironment` | `-1` | Use env defaults. |
+| `SerializeManaged` | `0` | Legacy full protobuf path. Serializes `CCitadelUserCmdPB` and calls `OnProcessUsercmds`. |
+| `Off` | `1` | Count nothing beyond hook entry; no protobuf/direct field reads. |
+| `CountOnly` | `2` | Count batches/cmds only. |
+| `DirectSample` | `3` | Read compact fields natively and log counters only. |
+| `FastDispatch` | `4` | Read compact fields and call `OnFastProcessUsercmds`. |
+| `MountedPolicy` | `5` | Production policy. Only mounted features do work. |
+
+Default when unset is `MountedPolicy`. With no mounts, the hook does not serialize protobufs and does not read nested usercmd fields.
+
+## Mounted features
+
+Managed API:
+
+```csharp
+if (NativeFeatures.HasCapability("usercmd.fast_read"))
+{
+    Usercmds.Visit(UsercmdFields.Buttons | UsercmdFields.ViewAngles | UsercmdFields.Movement);
+}
+
+Usercmds.MountButtonTriggers(InputButton.Attack | InputButton.Ability1);
+Usercmds.MountFullProtobuf(); // only for mutation/debug plugins
+```
+
+Plugin callbacks:
+
+```csharp
+public override void OnFastProcessUsercmds(FastProcessUsercmdsEvent args)
+{
+    var latest = args.Latest;
+    if (latest.HasButtons && latest.IsHeld(InputButton.Attack))
+    {
+        // Cheap read-only telemetry / anticheat / analytics path.
+    }
+}
+
+public override void OnUsercmdTrigger(UsercmdTriggerEvent args)
+{
+    // Fires only when native edge-triggered buttons match.
+}
+```
+
+`OnProcessUsercmds(ProcessUsercmdsEvent)` remains the full protobuf mutation/debug path. `PluginLoader` auto-mounts `FullProtobuf`, `FastRead`, and `ButtonTriggers` when a loaded plugin overrides the matching callback.
+
+## Fast fields
+
+`FastUsercmd` can carry:
+
+- command index
+- client tick
+- first 64-bit button state (`InputButton`)
+- pitch/yaw/roll
+- forward/left move
+- has-base/buttons/viewangles flags
+
+Use `Usercmds.Visit(UsercmdFields.X | UsercmdFields.Y)` or `DEADWORKS_USERCMD_FIELDS` to request only the fields a plugin needs. Reads are guarded by protobuf has-bits, pointer checks, and SEH. This path is read-only.
+
+## Environment profile
+
+See `config/deadworks_usercmd_visitors.env.example` for launch variables. The common production profile is:
+
+```text
+DEADWORKS_USERCMD_NATIVE_MODE=mounted
+DEADWORKS_USERCMD_MOUNTS=fast
+DEADWORKS_USERCMD_FIELDS=buttons,view,movement
+```
+
+Enable `DEADWORKS_USERCMD_PROBE_LOG=1` to emit `[UsercmdVisitor]` aggregate counters for benchmarking.
+
+## Examples
+
+Read only buttons, view angles, and movement without protobuf serialization:
+
+```csharp
+public override void OnLoad(bool isReload)
+{
+    Usercmds.Visit(UsercmdFields.Buttons | UsercmdFields.ViewAngles | UsercmdFields.Movement);
+}
+
+public override void OnFastProcessUsercmds(FastProcessUsercmdsEvent args)
+{
+    FastUsercmd latest = args.Latest;
+    if (latest.HasButtons && latest.IsHeld(InputButton.Attack))
+    {
+        // Read-only hot-path telemetry.
+    }
+}
+```
+
+Mount native edge-triggered button callbacks:
+
+```csharp
+public override void OnLoad(bool isReload)
+{
+    Usercmds.MountButtonTriggers(InputButton.Attack | InputButton.Jump);
+}
+
+public override void OnUsercmdTrigger(UsercmdTriggerEvent args)
+{
+    Console.WriteLine($"{args.PlayerSlot}: {args.TriggerButtons}");
+}
+```
+
+Use the legacy protobuf path for plugins that need full command protobuf access or mutation:
+
+```csharp
+public override void OnProcessUsercmds(ProcessUsercmdsEvent args)
+{
+    // Existing Deadworks plugins continue to work. PluginLoader mounts
+    // FullProtobuf automatically when this callback is overridden.
+}
+```
+
+## Public API shape
+
+The PR-facing managed names are Deadworks-generic and avoid product-specific wording:
+
+- `NativeFeatures.NativeApiVersion` and `NativeFeatures.HasCapability(...)`
+- `Usercmds`
+- `UsercmdFields`
+- `FastUsercmd`
+- `FastProcessUsercmdsEvent`
+- `UsercmdTriggerEvent`
+
+## Adding another visitor provider
+
+Use this shape when adding visitor support for another hot path, for example selected game-rule properties, pawn/controller telemetry, net-message summaries, or trace/visibility signals.
+
+### 1. Pick the provider hook
+
+Start from an existing Deadworks hook whenever possible. Good providers are hooks that already have the native object pointer and timing you need. Avoid adding a new hook if an existing one can publish the same stable data.
+
+A provider should define:
+
+- the native engine object(s) it observes;
+- when the snapshot is taken relative to engine processing;
+- whether the provider is read-only or supports a separate mutation path;
+- the minimum work done when no interest is mounted.
+
+### 2. Define a curated field catalog
+
+Add a `[Flags]` managed enum for fields, similar to `UsercmdFields`. Keep fields coarse enough that plugins can request intent without knowing offsets, but precise enough to avoid unnecessary reads.
+
+```csharp
+[Flags]
+public enum ExampleFields : uint
+{
+    None = 0,
+    Health = 1u << 0,
+    Team = 1u << 1,
+    Position = 1u << 2,
+    All = Health | Team | Position,
+}
+```
+
+Do not expose arbitrary "class + field + offset" reads as a visitor. If a field is useful in a hot path, add it to the catalog by name and document the semantics.
+
+### 3. Define the native/managed event ABI
+
+Use a blittable struct for native-to-managed dispatch. Include `Has*` flags when a field can be absent or failed to read.
+
+```csharp
+[StructLayout(LayoutKind.Sequential)]
+public struct FastExample
+{
+    public int EntityIndex;
+    public byte HasHealth;
+    public int Health;
+    public byte HasPosition;
+    public Vector3 Position;
+}
+```
+
+Keep ABI structs append-only once public. If a later change needs incompatible layout, add a new struct/callback or bump `NativeFeatures.NativeApiVersion` and gate the managed helper.
+
+### 4. Add mount and field-mask controls
+
+A provider needs native state equivalent to:
+
+- mode or enabled flag;
+- mounted features bitmask;
+- field mask;
+- optional predicate/trigger mask;
+- capability string in `HasNativeCapability`.
+
+For usercmds these are `UsercmdMount`, `UsercmdFields`, and capabilities like `usercmd.fast_read`.
+
+### 5. Auto-mount for compatibility callbacks
+
+If a pre-existing plugin callback requires expensive behavior, keep that callback working and mount the expensive path only when needed. Usercmds do this for `OnProcessUsercmds(ProcessUsercmdsEvent)` by mounting `FullProtobuf` only when a plugin overrides that method.
+
+New providers should follow the same rule: old plugins keep working, new plugins can choose cheaper visitor callbacks.
+
+### 6. Instrument and test
+
+Every provider should have counters for:
+
+- batches/events observed;
+- managed callbacks dispatched;
+- direct/native read operations;
+- direct read exceptions/failures;
+- expensive parse/serialize operations avoided or performed;
+- cumulative native/managed time when practical.
+
+E2E should cover:
+
+- no mounts: no expensive reads and no managed dispatch;
+- narrow field mask: only requested fields are read;
+- full/legacy mount if compatibility exists;
+- mixed deployment behavior via capability/null checks;
+- a live server/client smoke test.
+
+## Native callback ABI
+
+This change appends optional native callback entries to the managed callback table:
+
+- `GetNativeApiVersion`
+- `HasNativeCapability`
+- `SetUsercmdNativeMode` / `GetUsercmdNativeMode`
+- `SetUsercmdMountMask` / `GetUsercmdMountMask`
+- `SetUsercmdButtonTriggerMask` / `GetUsercmdButtonTriggerMask`
+- `SetUsercmdFieldMask` / `GetUsercmdFieldMask`
+
+The entries are appended after existing callbacks so existing plugins that never call the new API keep using the old callback surface. Managed helpers check for null callback pointers and report unsupported features with `NativeFeatures.NativeApiVersion == 0`, `NativeFeatures.HasCapability(...) == false`, or `NotSupportedException` for setter calls.
+
+Deploy native and managed artifacts from the same build when using the new visitor APIs.
+
+## E2E notes
+
+2026-05-29 local dedicated-server smoke test on `dl_midtown`:
+
+- Deadlock/Deadworks server booted and opened UDP `27067`.
+- Probe plugin loaded and mounted `FastRead` plus `ButtonTriggers`.
+- Client connected, reached full signon, moved/aimed/pressed buttons, then disconnected cleanly.
+- Visitor counters showed `serializedCmds=0`, `serializedBytes=0`, `serializeOps=0`, and `parseOps=0` on the fast visitor path.
+- Fast managed callbacks fired (`managedCallbacks > 0`).
+- Button trigger callbacks fired (`triggerCallbacks > 0`).
+- Native direct reads succeeded with `directExceptions=0` while reading buttons, view angles, and movement.
+- Existing local plugin smoke test: `DeadlockBhopRuntime.dll` loaded on `dl_midtown`, registered its commands, and did not call the new visitor APIs.
+- Runtime long-frame checks were repeated with a quiet probe and with an empty plugin directory/no usercmd mounts. Long frames still reproduced in the empty baseline, while visitor counters stayed at zero/disabled, indicating those long frames are baseline Deadlock/Deadworks server behavior rather than visitor-induced work.
+
+Additional E2E modes to run with a connected client before merge:
+
+- Legacy-only plugin overriding `OnProcessUsercmds(ProcessUsercmdsEvent)` should show `FullProtobuf` auto-mounted and legacy callback counters increasing.
+- Buttons-only plugin using `Usercmds.Visit(UsercmdFields.Buttons)` should show button reads/callbacks without angle or movement reads.

--- a/examples/ExamplePlugins.slnx
+++ b/examples/ExamplePlugins.slnx
@@ -2,6 +2,7 @@
   <Project Path="plugins/AutoRestartPlugin/AutoRestartPlugin.csproj" />
   <Project Path="plugins/ChatRelayPlugin/ChatRelayPlugin.csproj" />
   <Project Path="plugins/DeathmatchPlugin/DeathmatchPlugin.csproj" />
+  <Project Path="plugins/DiagnosticsPlugin/DiagnosticsPlugin.csproj" />
   <Project Path="plugins/DumperPlugin/DumperPlugin.csproj" />
   <Project Path="plugins/ExampleTimerPlugin/ExampleTimerPlugin.csproj" />
   <Project Path="plugins/ItemRotationPlugin/ItemRotationPlugin.csproj" />

--- a/examples/plugins/DiagnosticsPlugin/DiagnosticsPlugin.cs
+++ b/examples/plugins/DiagnosticsPlugin/DiagnosticsPlugin.cs
@@ -1,0 +1,212 @@
+using System.Numerics;
+using DeadworksManaged.Api;
+
+namespace DiagnosticsPlugin;
+
+public sealed class DiagnosticsPlugin : DeadworksPluginBase
+{
+    public override string Name => "Diagnostics";
+
+    private readonly List<IHandle> _handles = [];
+    private readonly Dictionary<int, int> _usercmdBatches = new();
+    private readonly bool _verboseTouch = EnvEnabled("DEADWORKS_DIAGNOSTICS_VERBOSE_TOUCH");
+    private long _touchStarts;
+    private long _touchEnds;
+    private string? _lastTouchStart;
+    private string? _lastTouchEnd;
+
+    public override void OnLoad(bool isReload)
+    {
+        _handles.Add(Timer.Every(5.Seconds(), FlushTouchSummary));
+
+        if (NativeFeatures.HasCapability("netmsg.fast_read"))
+        {
+            _handles.Add(NetMessages.VisitIncoming((int)CLC_Messages.ClcRequestPause));
+            _handles.Add(NetMessages.VisitOutgoing((int)SVC_Messages.SvcSetPause));
+            _handles.Add(NetMessages.VisitUserMessage<CCitadelUserMsg_ChatMsg>());
+        }
+
+        Console.WriteLine(isReload ? "[Diagnostics] reloaded" : "[Diagnostics] loaded");
+    }
+
+    public override void OnUnload()
+    {
+        foreach (var handle in _handles)
+            handle.Cancel();
+        _handles.Clear();
+        Console.WriteLine("[Diagnostics] unloaded");
+    }
+
+    public override void OnFastProcessUsercmds(FastProcessUsercmdsEvent args)
+    {
+        int count = _usercmdBatches.GetValueOrDefault(args.PlayerSlot) + 1;
+        _usercmdBatches[args.PlayerSlot] = count;
+        if (count % 500 != 0)
+            return;
+
+        var latest = args.Latest;
+        Console.WriteLine($"[Diagnostics] usercmd slot={args.PlayerSlot} cmds={args.Usercmds.Length} tick={latest.ClientTick} buttons=0x{latest.Buttons:X} yaw={latest.Yaw:F1}");
+    }
+
+    public override void OnFastNetMessage(FastNetMessageEvent args)
+    {
+        if (args.HasPauseRequest)
+        {
+            Console.WriteLine($"[Diagnostics] net pause request slot={args.EndpointSlot} type={args.PauseType} group={args.PauseGroup}");
+            return;
+        }
+
+        if (args.HasPauseState)
+        {
+            Console.WriteLine($"[Diagnostics] net pause state paused={args.Paused} recipients=0x{args.RecipientMask:X}");
+            return;
+        }
+
+        if (args.HasUserMessageType)
+            Console.WriteLine($"[Diagnostics] net usermessage type={args.UserMessageType} recipients=0x{args.RecipientMask:X}");
+    }
+
+    public override HookResult OnChatMessage(ChatMessage message)
+    {
+        Console.WriteLine($"[Diagnostics] chat slot={message.SenderSlot} all={message.AllChat}: {message.ChatText}");
+        return HookResult.Continue;
+    }
+
+    public override void OnClientFullConnect(ClientFullConnectEvent args)
+        => Console.WriteLine($"[Diagnostics] client full connect slot={args.Slot}");
+
+    public override void OnClientDisconnect(ClientDisconnectedEvent args)
+        => Console.WriteLine($"[Diagnostics] client disconnect slot={args.Slot} reason={args.Reason}");
+
+    public override void OnEntityStartTouch(EntityTouchEvent args)
+        => RecordTouch(started: true, args);
+
+    public override void OnEntityEndTouch(EntityTouchEvent args)
+        => RecordTouch(started: false, args);
+
+    [GameEventHandler("player_death")]
+    public HookResult OnPlayerDeath(PlayerDeathEvent args)
+    {
+        Console.WriteLine($"[Diagnostics] gameevent player_death victim={args.UseridPawn?.EntityIndex ?? -1} attacker={args.AttackerPawn?.EntityIndex ?? -1}");
+        return HookResult.Continue;
+    }
+
+    [GameEventHandler("player_respawned")]
+    public HookResult OnPlayerRespawned(PlayerRespawnedEvent args)
+    {
+        Console.WriteLine($"[Diagnostics] gameevent player_respawned pawn={args.Userid?.EntityIndex ?? -1}");
+        return HookResult.Continue;
+    }
+
+    [Command("heal", Description = "Heal yourself by N health")]
+    public void Heal(CCitadelPlayerController caller, float amount)
+    {
+        var pawn = RequirePawn(caller);
+        int healed = pawn.Heal(MathF.Max(0, amount));
+        Reply(caller, $"Healed {healed}. Health={pawn.Health}/{pawn.GetMaxHealth()}");
+        Console.WriteLine($"[Diagnostics] /heal slot={caller.Slot} amount={amount} healed={healed}");
+    }
+
+    [Command("damage", Description = "Damage yourself by N health")]
+    public void Damage(CCitadelPlayerController caller, float amount)
+    {
+        var pawn = RequirePawn(caller);
+        pawn.Hurt(MathF.Max(0, amount), attacker: pawn, inflictor: pawn);
+        Reply(caller, $"Damaged {amount}. Health={pawn.Health}/{pawn.GetMaxHealth()}");
+        Console.WriteLine($"[Diagnostics] /damage slot={caller.Slot} amount={amount}");
+    }
+
+    [Command("teleport", "tp", Description = "Teleport to the point you are looking at")]
+    public void Teleport(CCitadelPlayerController caller)
+    {
+        var pawn = RequirePawn(caller);
+        var forward = ForwardFromAngles(pawn.ViewAngles);
+        var start = pawn.EyePosition;
+        var end = start + forward * 8192f;
+        var trace = Trace.Ray(start, end, ignore: pawn);
+        var destination = (trace.DidHit ? trace.HitPosition - forward * 48f : end) + new Vector3(0, 0, 16f);
+
+        pawn.Teleport(position: destination, velocity: Vector3.Zero);
+        Reply(caller, $"Teleported to {destination.X:F0}, {destination.Y:F0}, {destination.Z:F0}");
+        Console.WriteLine($"[Diagnostics] /teleport slot={caller.Slot} hit={trace.DidHit} dest={destination}");
+    }
+
+    [Command("respawn", Description = "Request an immediate respawn")]
+    public void Respawn(CCitadelPlayerController caller)
+    {
+        var pawn = caller.GetHeroPawn();
+        if (pawn != null)
+            pawn.RespawnTime = 0;
+        Server.ClientCommand(caller.Slot, "respawn");
+        Reply(caller, "Respawn requested");
+        Console.WriteLine($"[Diagnostics] /respawn slot={caller.Slot}");
+    }
+
+    private void RecordTouch(bool started, EntityTouchEvent args)
+    {
+        string description = $"{Describe(args.Entity)} -> {Describe(args.Other)}";
+        if (_verboseTouch)
+        {
+            Console.WriteLine($"[Diagnostics] touch {(started ? "start" : "end")} {description}");
+            return;
+        }
+
+        if (started)
+        {
+            _touchStarts++;
+            _lastTouchStart = description;
+        }
+        else
+        {
+            _touchEnds++;
+            _lastTouchEnd = description;
+        }
+    }
+
+    private void FlushTouchSummary()
+    {
+        if (_verboseTouch)
+            return;
+
+        long starts = _touchStarts;
+        long ends = _touchEnds;
+        if (starts == 0 && ends == 0)
+            return;
+
+        _touchStarts = 0;
+        _touchEnds = 0;
+        string lastStart = _lastTouchStart ?? "<none>";
+        string lastEnd = _lastTouchEnd ?? "<none>";
+        _lastTouchStart = null;
+        _lastTouchEnd = null;
+        Console.WriteLine($"[Diagnostics] touch summary start={starts} end={ends} lastStart={lastStart} lastEnd={lastEnd}");
+    }
+
+    private static CCitadelPlayerPawn RequirePawn(CCitadelPlayerController caller)
+        => caller.GetHeroPawn() ?? throw new CommandException("You do not have a hero pawn yet.");
+
+    private static void Reply(CCitadelPlayerController caller, string message)
+        => Chat.PrintToChat(caller, "[Diagnostics] " + message);
+
+    private static bool EnvEnabled(string name)
+    {
+        string? value = Environment.GetEnvironmentVariable(name);
+        return !string.IsNullOrWhiteSpace(value)
+            && value != "0"
+            && !string.Equals(value, "false", StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(value, "off", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string Describe(CBaseEntity? entity)
+        => entity == null || !entity.IsValid ? "<null>" : $"{entity.Classname}#{entity.EntityIndex}";
+
+    private static Vector3 ForwardFromAngles(Vector3 angles)
+    {
+        float pitch = angles.X * MathF.PI / 180f;
+        float yaw = angles.Y * MathF.PI / 180f;
+        return Vector3.Normalize(new Vector3(
+            MathF.Cos(pitch) * MathF.Cos(yaw),
+            MathF.Cos(pitch) * MathF.Sin(yaw),
+            -MathF.Sin(pitch)));
+    }
+}

--- a/examples/plugins/DiagnosticsPlugin/DiagnosticsPlugin.csproj
+++ b/examples/plugins/DiagnosticsPlugin/DiagnosticsPlugin.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\managed\DeadworksManaged.Api\DeadworksManaged.Api.csproj">
+      <Private>false</Private>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
+  </ItemGroup>
+
+  <Target Name="DeployToGame" AfterTargets="Build">
+    <ItemGroup>
+      <DeployFiles Include="$(OutputPath)DiagnosticsPlugin.dll;$(OutputPath)DiagnosticsPlugin.pdb" />
+    </ItemGroup>
+    <Copy SourceFiles="@(DeployFiles)" DestinationFolder="$(DeadlockManagedDir)\plugins" SkipUnchangedFiles="false" Retries="0" ContinueOnError="WarnAndContinue" />
+  </Target>
+
+</Project>

--- a/examples/plugins/DiagnosticsPlugin/README.md
+++ b/examples/plugins/DiagnosticsPlugin/README.md
@@ -1,0 +1,19 @@
+# DiagnosticsPlugin
+
+Example plugin for exercising visitor paths and common admin-style commands.
+
+It mounts:
+
+- fast usercmd callbacks via `OnFastProcessUsercmds`
+- fast net-message visitors for pause state/request and chat `svc_UserMessage` inner ids
+- chat command serialization through `OnChatMessage` / command registration
+- selected game events and entity touch callbacks
+
+Commands:
+
+- `/heal N`
+- `/damage N`
+- `/teleport` or `/tp`
+- `/respawn`
+
+This plugin is meant for local diagnostics, not production servers. High-frequency entity touch events are summarized every 5 seconds by default; set `DEADWORKS_DIAGNOSTICS_VERBOSE_TOUCH=1` for per-touch logging.

--- a/managed/DeadworksManaged.Api/DeadworksPluginBase.cs
+++ b/managed/DeadworksManaged.Api/DeadworksPluginBase.cs
@@ -30,6 +30,8 @@ public abstract class DeadworksPluginBase : IDeadworksPlugin {
 	public virtual void OnEntityEndTouch(EntityTouchEvent args) { }
 	public virtual void OnAbilityAttempt(AbilityAttemptEvent args) { }
 	public virtual void OnProcessUsercmds(ProcessUsercmdsEvent args) { }
+	public virtual void OnFastProcessUsercmds(FastProcessUsercmdsEvent args) { }
+	public virtual void OnUsercmdTrigger(UsercmdTriggerEvent args) { }
 	public virtual HookResult OnAddModifier(AddModifierEvent args) => HookResult.Continue;
 	public virtual void OnConfigReloaded() { }
 	public virtual void OnCheckTransmit(CheckTransmitEvent args) { }

--- a/managed/DeadworksManaged.Api/DeadworksPluginBase.cs
+++ b/managed/DeadworksManaged.Api/DeadworksPluginBase.cs
@@ -32,6 +32,7 @@ public abstract class DeadworksPluginBase : IDeadworksPlugin {
 	public virtual void OnProcessUsercmds(ProcessUsercmdsEvent args) { }
 	public virtual void OnFastProcessUsercmds(FastProcessUsercmdsEvent args) { }
 	public virtual void OnUsercmdTrigger(UsercmdTriggerEvent args) { }
+	public virtual void OnFastNetMessage(FastNetMessageEvent args) { }
 	public virtual HookResult OnAddModifier(AddModifierEvent args) => HookResult.Continue;
 	public virtual void OnConfigReloaded() { }
 	public virtual void OnCheckTransmit(CheckTransmitEvent args) { }

--- a/managed/DeadworksManaged.Api/Events/FastNetMessageEvent.cs
+++ b/managed/DeadworksManaged.Api/Events/FastNetMessageEvent.cs
@@ -1,0 +1,42 @@
+namespace DeadworksManaged.Api;
+
+/// <summary>
+/// Compact native-extracted net message observation. This is the read-only visitor path;
+/// use <see cref="NetMessages.HookIncoming{T}"/> or <see cref="NetMessages.HookOutgoing{T}"/>
+/// when a plugin needs the full protobuf object or mutation/blocking semantics.
+/// </summary>
+public sealed class FastNetMessageEvent
+{
+    /// <summary>Message direction relative to the server.</summary>
+    public required NetMessageDirection Direction { get; init; }
+
+    /// <summary>Incoming sender slot, or -1 for outgoing messages.</summary>
+    public required int EndpointSlot { get; init; }
+
+    /// <summary>Source 2 net message id.</summary>
+    public required int MessageId { get; init; }
+
+    /// <summary>Outgoing recipient mask, or zero for incoming messages.</summary>
+    public required ulong RecipientMask { get; init; }
+
+    /// <summary>True when this is an outgoing <c>svc_UserMessage</c> and <see cref="UserMessageType"/> is populated.</summary>
+    public required bool HasUserMessageType { get; init; }
+
+    /// <summary>Nested user-message id for <c>svc_UserMessage</c>, or -1 when unavailable.</summary>
+    public required int UserMessageType { get; init; }
+
+    /// <summary>True when this is an incoming pause request and pause request fields are populated.</summary>
+    public required bool HasPauseRequest { get; init; }
+
+    /// <summary>Pause request type for <c>clc_RequestPause</c>.</summary>
+    public required int PauseType { get; init; }
+
+    /// <summary>Pause request group for <c>clc_RequestPause</c>.</summary>
+    public required int PauseGroup { get; init; }
+
+    /// <summary>True when this is an outgoing pause state update and <see cref="Paused"/> is populated.</summary>
+    public required bool HasPauseState { get; init; }
+
+    /// <summary>Pause state for <c>svc_SetPause</c>.</summary>
+    public required bool Paused { get; init; }
+}

--- a/managed/DeadworksManaged.Api/Events/FastProcessUsercmdsEvent.cs
+++ b/managed/DeadworksManaged.Api/Events/FastProcessUsercmdsEvent.cs
@@ -1,0 +1,57 @@
+using System.Runtime.InteropServices;
+
+namespace DeadworksManaged.Api;
+
+/// <summary>
+/// Compact, native-extracted usercmd fields. This avoids protobuf serialization/parsing and is
+/// intended for high-frequency read-only plugins (telemetry, anticheat, input analytics).
+/// </summary>
+[StructLayout(LayoutKind.Sequential)]
+public readonly struct FastUsercmd
+{
+    public readonly int CommandIndex;
+    public readonly int ClientTick;
+    public readonly ulong ButtonsRaw;
+    public readonly float Pitch;
+    public readonly float Yaw;
+    public readonly float Roll;
+    public readonly float ForwardMove;
+    public readonly float LeftMove;
+    private readonly int _hasBase;
+    private readonly int _hasButtons;
+    private readonly int _hasViewAngles;
+
+    public bool HasBase => _hasBase != 0;
+    public bool HasButtons => _hasButtons != 0;
+    public bool HasViewAngles => _hasViewAngles != 0;
+    public InputButton Buttons => (InputButton)ButtonsRaw;
+
+    public bool IsHeld(InputButton button) => (Buttons & button) != 0;
+}
+
+/// <summary>
+/// Read-only fast usercmd event. For mutation, use <see cref="ProcessUsercmdsEvent"/> instead;
+/// this event is optimized for cheap observation.
+/// </summary>
+public sealed class FastProcessUsercmdsEvent
+{
+    public required int PlayerSlot { get; init; }
+    public required FastUsercmd[] Usercmds { get; init; }
+    public required bool Paused { get; init; }
+    public required float Margin { get; init; }
+
+    public int Count => Usercmds.Length;
+    public FastUsercmd Latest => Usercmds.Length > 0 ? Usercmds[^1] : default;
+
+    [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+    public unsafe CCitadelPlayerController? Controller
+    {
+        get
+        {
+            if (NativeInterop.GetPlayerController == null)
+                return null;
+            var ptr = NativeInterop.GetPlayerController(PlayerSlot);
+            return ptr != null ? new CCitadelPlayerController((nint)ptr) : null;
+        }
+    }
+}

--- a/managed/DeadworksManaged.Api/Events/ProcessUsercmdsEvent.cs
+++ b/managed/DeadworksManaged.Api/Events/ProcessUsercmdsEvent.cs
@@ -1,6 +1,6 @@
 namespace DeadworksManaged.Api;
 
-/// <summary>Event data passed to <see cref="IDeadworksPlugin.OnProcessUsercmds"/>. Contains the player slot, parsed usercmd protobuf messages, and timing info.</summary>
+/// <summary>Event data passed to <see cref="IDeadworksPlugin.OnProcessUsercmds"/>. This is the full protobuf mutation/debug path; use <see cref="FastProcessUsercmdsEvent"/> for cheap read-only telemetry.</summary>
 public sealed class ProcessUsercmdsEvent {
 	/// <summary>Player slot (0-63).</summary>
 	public required int PlayerSlot { get; init; }

--- a/managed/DeadworksManaged.Api/Events/UsercmdTriggerEvent.cs
+++ b/managed/DeadworksManaged.Api/Events/UsercmdTriggerEvent.cs
@@ -1,0 +1,27 @@
+namespace DeadworksManaged.Api;
+
+/// <summary>
+/// Native-fired usercmd trigger. Produced only when a mounted native predicate matches
+/// (for example, a watched button transitions from up to down).
+/// </summary>
+public sealed class UsercmdTriggerEvent
+{
+    public required int PlayerSlot { get; init; }
+    public required FastUsercmd Usercmd { get; init; }
+    public required InputButton PressedButtons { get; init; }
+    public required InputButton TriggerButtons { get; init; }
+    public required bool Paused { get; init; }
+    public required float Margin { get; init; }
+
+    [System.Diagnostics.DebuggerBrowsable(System.Diagnostics.DebuggerBrowsableState.Never)]
+    public unsafe CCitadelPlayerController? Controller
+    {
+        get
+        {
+            if (NativeInterop.GetPlayerController == null)
+                return null;
+            var ptr = NativeInterop.GetPlayerController(PlayerSlot);
+            return ptr != null ? new CCitadelPlayerController((nint)ptr) : null;
+        }
+    }
+}

--- a/managed/DeadworksManaged.Api/IDeadworksPlugin.cs
+++ b/managed/DeadworksManaged.Api/IDeadworksPlugin.cs
@@ -105,8 +105,14 @@ public interface IDeadworksPlugin {
 	/// </summary>
 	void OnAbilityAttempt(AbilityAttemptEvent args) { }
 
-	/// <summary>Called when a player's usercmds are being processed.</summary>
+	/// <summary>Called when a player's usercmds are being processed through the full protobuf mutation/debug path.</summary>
 	void OnProcessUsercmds(ProcessUsercmdsEvent args) { }
+
+	/// <summary>Called with compact native-extracted usercmd fields. Read-only and cheaper than full protobuf parsing.</summary>
+	void OnFastProcessUsercmds(FastProcessUsercmdsEvent args) { }
+
+	/// <summary>Called when a mounted native usercmd trigger matches, such as a watched button edge.</summary>
+	void OnUsercmdTrigger(UsercmdTriggerEvent args) { }
 
 	/// <summary>Called after the plugin's config has been reloaded via <c>dw_reloadconfig</c>.</summary>
 	void OnConfigReloaded() { }

--- a/managed/DeadworksManaged.Api/IDeadworksPlugin.cs
+++ b/managed/DeadworksManaged.Api/IDeadworksPlugin.cs
@@ -114,6 +114,9 @@ public interface IDeadworksPlugin {
 	/// <summary>Called when a mounted native usercmd trigger matches, such as a watched button edge.</summary>
 	void OnUsercmdTrigger(UsercmdTriggerEvent args) { }
 
+	/// <summary>Called with compact native-extracted net message fields for mounted net message visitors.</summary>
+	void OnFastNetMessage(FastNetMessageEvent args) { }
+
 	/// <summary>Called after the plugin's config has been reloaded via <c>dw_reloadconfig</c>.</summary>
 	void OnConfigReloaded() { }
 

--- a/managed/DeadworksManaged.Api/NativeCallbacks.cs
+++ b/managed/DeadworksManaged.Api/NativeCallbacks.cs
@@ -137,4 +137,12 @@ internal struct NativeCallbacks
 	public nint GetUsercmdButtonTriggerMask;
 	public nint SetUsercmdFieldMask;
 	public nint GetUsercmdFieldMask;
+	public nint SetNetMessageSerializedInterest;
+	public nint HasNetMessageSerializedInterest;
+	public nint SetNetMessageFastInterest;
+	public nint HasNetMessageFastInterest;
+	public nint SetUserMessageFastInterest;
+	public nint HasUserMessageFastInterest;
+	public nint SetUserMessageSerializedInterest;
+	public nint HasUserMessageSerializedInterest;
 }

--- a/managed/DeadworksManaged.Api/NativeCallbacks.cs
+++ b/managed/DeadworksManaged.Api/NativeCallbacks.cs
@@ -127,4 +127,14 @@ internal struct NativeCallbacks
 	public nint VariantToVector;
 	public nint VariantToColor;
 	public nint AddConCommandFlags;
+	public nint GetNativeApiVersion;
+	public nint HasNativeCapability;
+	public nint SetUsercmdNativeMode;
+	public nint GetUsercmdNativeMode;
+	public nint SetUsercmdMountMask;
+	public nint GetUsercmdMountMask;
+	public nint SetUsercmdButtonTriggerMask;
+	public nint GetUsercmdButtonTriggerMask;
+	public nint SetUsercmdFieldMask;
+	public nint GetUsercmdFieldMask;
 }

--- a/managed/DeadworksManaged.Api/NativeFeatures.cs
+++ b/managed/DeadworksManaged.Api/NativeFeatures.cs
@@ -1,0 +1,146 @@
+namespace DeadworksManaged.Api;
+
+/// <summary>Discovery helpers for optional capabilities provided by this Deadworks native runtime.</summary>
+public static unsafe class NativeFeatures
+{
+    public static uint NativeApiVersion => NativeInterop.GetNativeApiVersion != null ? NativeInterop.GetNativeApiVersion() : 0;
+
+    public static bool HasCapability(string capabilityName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(capabilityName);
+        if (NativeInterop.HasNativeCapability == null)
+            return false;
+
+        Span<byte> utf8 = Utf8.Encode(capabilityName, stackalloc byte[Utf8.Size(capabilityName)]);
+        fixed (byte* ptr = utf8)
+        {
+            return NativeInterop.HasNativeCapability(ptr) != 0;
+        }
+    }
+}
+
+public enum UsercmdNativeMode
+{
+    DefaultFromEnvironment = -1,
+    SerializeManaged = 0,
+    Off = 1,
+    CountOnly = 2,
+    DirectSample = 3,
+    FastDispatch = 4,
+    MountedPolicy = 5,
+}
+
+[Flags]
+public enum UsercmdMount : uint
+{
+    None = 0,
+    FullProtobuf = 1u << 0,
+    FastRead = 1u << 1,
+    ButtonTriggers = 1u << 2,
+    All = FullProtobuf | FastRead | ButtonTriggers,
+}
+
+[Flags]
+public enum UsercmdFields : uint
+{
+    None = 0,
+    ClientTick = 1u << 0,
+    Buttons = 1u << 1,
+    ViewAngles = 1u << 2,
+    Movement = 1u << 3,
+    All = ClientTick | Buttons | ViewAngles | Movement,
+}
+
+/// <summary>
+/// Controls the native usercmd hook. The mounted policy is the production path:
+/// with no mounts it only counts batches, and it only performs protobuf/direct reads
+/// for features explicitly mounted by a plugin or environment variable.
+/// </summary>
+public static unsafe class Usercmds
+{
+    /// <summary>Mounts the read-only fast native field extraction path.</summary>
+    public static void EnableFastRead() => Visit(UsercmdFields.All);
+
+    /// <summary>Mounts the read-only fast native field extraction path for the requested fields.</summary>
+    public static void Visit(UsercmdFields fields)
+    {
+        SetFieldMask(fields == UsercmdFields.None ? UsercmdFields.All : fields);
+        Mount(UsercmdMount.FastRead);
+        SetNativeMode(UsercmdNativeMode.MountedPolicy);
+    }
+
+    /// <summary>Mounts the legacy full-protobuf path used by <see cref="IDeadworksPlugin.OnProcessUsercmds"/>.</summary>
+    public static void MountFullProtobuf()
+    {
+        Mount(UsercmdMount.FullProtobuf);
+        SetNativeMode(UsercmdNativeMode.MountedPolicy);
+    }
+
+    /// <summary>Mounts native edge-trigger callbacks for the supplied buttons.</summary>
+    public static void MountButtonTriggers(InputButton buttons)
+    {
+        SetButtonTriggerMask(buttons);
+        Mount(UsercmdMount.ButtonTriggers);
+        SetNativeMode(UsercmdNativeMode.MountedPolicy);
+    }
+
+    public static void Mount(UsercmdMount features) => SetMountMask(GetMountMask() | features);
+
+    public static void Unmount(UsercmdMount features) => SetMountMask(GetMountMask() & ~features);
+
+    public static void SetMountMask(UsercmdMount mount)
+    {
+        if (NativeInterop.SetUsercmdMountMask == null)
+            throw new NotSupportedException("Native usercmd mount control is not available in this Deadworks build.");
+        NativeInterop.SetUsercmdMountMask((uint)mount);
+    }
+
+    public static UsercmdMount GetMountMask()
+    {
+        if (NativeInterop.GetUsercmdMountMask == null)
+            return UsercmdMount.None;
+        return (UsercmdMount)NativeInterop.GetUsercmdMountMask();
+    }
+
+    public static void SetButtonTriggerMask(InputButton buttons)
+    {
+        if (NativeInterop.SetUsercmdButtonTriggerMask == null)
+            throw new NotSupportedException("Native usercmd trigger control is not available in this Deadworks build.");
+        NativeInterop.SetUsercmdButtonTriggerMask((ulong)buttons);
+    }
+
+    public static InputButton GetButtonTriggerMask()
+    {
+        if (NativeInterop.GetUsercmdButtonTriggerMask == null)
+            return InputButton.None;
+        return (InputButton)NativeInterop.GetUsercmdButtonTriggerMask();
+    }
+
+    public static void SetFieldMask(UsercmdFields fields)
+    {
+        if (NativeInterop.SetUsercmdFieldMask == null)
+            throw new NotSupportedException("Native usercmd field-mask control is not available in this Deadworks build.");
+        NativeInterop.SetUsercmdFieldMask((uint)fields);
+    }
+
+    public static UsercmdFields GetFieldMask()
+    {
+        if (NativeInterop.GetUsercmdFieldMask == null)
+            return UsercmdFields.All;
+        return (UsercmdFields)NativeInterop.GetUsercmdFieldMask();
+    }
+
+    public static void SetNativeMode(UsercmdNativeMode mode)
+    {
+        if (NativeInterop.SetUsercmdNativeMode == null)
+            throw new NotSupportedException("Native usercmd mode control is not available in this Deadworks build.");
+        NativeInterop.SetUsercmdNativeMode((int)mode);
+    }
+
+    public static UsercmdNativeMode GetNativeMode()
+    {
+        if (NativeInterop.GetUsercmdNativeMode == null)
+            return UsercmdNativeMode.SerializeManaged;
+        return (UsercmdNativeMode)NativeInterop.GetUsercmdNativeMode();
+    }
+}

--- a/managed/DeadworksManaged.Api/NativeInterop.cs
+++ b/managed/DeadworksManaged.Api/NativeInterop.cs
@@ -129,4 +129,16 @@ internal static unsafe class NativeInterop
 	public static delegate* unmanaged[Cdecl]<void*, float*, void> VariantToVector => (delegate* unmanaged[Cdecl]<void*, float*, void>)_cb.VariantToVector;
 	public static delegate* unmanaged[Cdecl]<void*, uint> VariantToColor => (delegate* unmanaged[Cdecl]<void*, uint>)_cb.VariantToColor;
 	public static delegate* unmanaged[Cdecl]<byte*, ulong, byte> AddConCommandFlags => (delegate* unmanaged[Cdecl]<byte*, ulong, byte>)_cb.AddConCommandFlags;
+
+	// Deadworks visitor API
+	public static delegate* unmanaged[Cdecl]<uint> GetNativeApiVersion => (delegate* unmanaged[Cdecl]<uint>)_cb.GetNativeApiVersion;
+	public static delegate* unmanaged[Cdecl]<byte*, byte> HasNativeCapability => (delegate* unmanaged[Cdecl]<byte*, byte>)_cb.HasNativeCapability;
+	public static delegate* unmanaged[Cdecl]<int, void> SetUsercmdNativeMode => (delegate* unmanaged[Cdecl]<int, void>)_cb.SetUsercmdNativeMode;
+	public static delegate* unmanaged[Cdecl]<int> GetUsercmdNativeMode => (delegate* unmanaged[Cdecl]<int>)_cb.GetUsercmdNativeMode;
+	public static delegate* unmanaged[Cdecl]<uint, void> SetUsercmdMountMask => (delegate* unmanaged[Cdecl]<uint, void>)_cb.SetUsercmdMountMask;
+	public static delegate* unmanaged[Cdecl]<uint> GetUsercmdMountMask => (delegate* unmanaged[Cdecl]<uint>)_cb.GetUsercmdMountMask;
+	public static delegate* unmanaged[Cdecl]<ulong, void> SetUsercmdButtonTriggerMask => (delegate* unmanaged[Cdecl]<ulong, void>)_cb.SetUsercmdButtonTriggerMask;
+	public static delegate* unmanaged[Cdecl]<ulong> GetUsercmdButtonTriggerMask => (delegate* unmanaged[Cdecl]<ulong>)_cb.GetUsercmdButtonTriggerMask;
+	public static delegate* unmanaged[Cdecl]<uint, void> SetUsercmdFieldMask => (delegate* unmanaged[Cdecl]<uint, void>)_cb.SetUsercmdFieldMask;
+	public static delegate* unmanaged[Cdecl]<uint> GetUsercmdFieldMask => (delegate* unmanaged[Cdecl]<uint>)_cb.GetUsercmdFieldMask;
 }

--- a/managed/DeadworksManaged.Api/NativeInterop.cs
+++ b/managed/DeadworksManaged.Api/NativeInterop.cs
@@ -141,4 +141,12 @@ internal static unsafe class NativeInterop
 	public static delegate* unmanaged[Cdecl]<ulong> GetUsercmdButtonTriggerMask => (delegate* unmanaged[Cdecl]<ulong>)_cb.GetUsercmdButtonTriggerMask;
 	public static delegate* unmanaged[Cdecl]<uint, void> SetUsercmdFieldMask => (delegate* unmanaged[Cdecl]<uint, void>)_cb.SetUsercmdFieldMask;
 	public static delegate* unmanaged[Cdecl]<uint> GetUsercmdFieldMask => (delegate* unmanaged[Cdecl]<uint>)_cb.GetUsercmdFieldMask;
+	public static delegate* unmanaged[Cdecl]<int, int, byte, void> SetNetMessageSerializedInterest => (delegate* unmanaged[Cdecl]<int, int, byte, void>)_cb.SetNetMessageSerializedInterest;
+	public static delegate* unmanaged[Cdecl]<int, int, byte> HasNetMessageSerializedInterest => (delegate* unmanaged[Cdecl]<int, int, byte>)_cb.HasNetMessageSerializedInterest;
+	public static delegate* unmanaged[Cdecl]<int, int, byte, void> SetNetMessageFastInterest => (delegate* unmanaged[Cdecl]<int, int, byte, void>)_cb.SetNetMessageFastInterest;
+	public static delegate* unmanaged[Cdecl]<int, int, byte> HasNetMessageFastInterest => (delegate* unmanaged[Cdecl]<int, int, byte>)_cb.HasNetMessageFastInterest;
+	public static delegate* unmanaged[Cdecl]<int, byte, void> SetUserMessageFastInterest => (delegate* unmanaged[Cdecl]<int, byte, void>)_cb.SetUserMessageFastInterest;
+	public static delegate* unmanaged[Cdecl]<int, byte> HasUserMessageFastInterest => (delegate* unmanaged[Cdecl]<int, byte>)_cb.HasUserMessageFastInterest;
+	public static delegate* unmanaged[Cdecl]<int, byte, void> SetUserMessageSerializedInterest => (delegate* unmanaged[Cdecl]<int, byte, void>)_cb.SetUserMessageSerializedInterest;
+	public static delegate* unmanaged[Cdecl]<int, byte> HasUserMessageSerializedInterest => (delegate* unmanaged[Cdecl]<int, byte>)_cb.HasUserMessageSerializedInterest;
 }

--- a/managed/DeadworksManaged.Api/NetMessages/NetMessageRegistry.cs
+++ b/managed/DeadworksManaged.Api/NetMessages/NetMessageRegistry.cs
@@ -12,6 +12,7 @@ public static class NetMessageRegistry
 {
 	private static readonly Dictionary<Type, int> s_typeToId = new();
 	private static readonly Dictionary<int, MessageParser> s_idToParser = new();
+	private static readonly HashSet<int> s_userMessageIds = new();
 	private static bool s_initialized;
 
 	internal static void EnsureInitialized()
@@ -42,6 +43,12 @@ public static class NetMessageRegistry
 	{
 		EnsureInitialized();
 		return s_idToParser.TryGetValue(messageId, out var parser) ? parser : null;
+	}
+
+	internal static bool IsUserMessageId(int messageId)
+	{
+		EnsureInitialized();
+		return s_userMessageIds.Contains(messageId);
 	}
 
 	private static void BuildRegistry()
@@ -115,8 +122,13 @@ public static class NetMessageRegistry
 
 		if (mapper == null) return;
 
+		bool isUserMessageEnum = enumDesc.Name is "CitadelUserMessageIds" or "EBaseUserMessages";
+
 		foreach (var value in enumDesc.Values)
 		{
+			if (isUserMessageEnum)
+				s_userMessageIds.Add(value.Number);
+
 			var className = mapper(value.Name);
 			if (className == null) continue;
 

--- a/managed/DeadworksManaged.Api/NetMessages/NetMessages.cs
+++ b/managed/DeadworksManaged.Api/NetMessages/NetMessages.cs
@@ -6,11 +6,17 @@ namespace DeadworksManaged.Api;
 /// Entry point for sending and hooking Source 2 network messages.
 /// Messages are identified by their protobuf type; IDs are resolved via <see cref="NetMessageRegistry"/>.
 /// </summary>
-public static class NetMessages
+public static unsafe class NetMessages
 {
 	internal static Action<int, byte[], ulong>? OnSend;
 	internal static Func<int, NetMessageDirection, Delegate, IHandle>? OnHookAdd;
 	internal static Action<int, NetMessageDirection, Delegate>? OnHookRemove;
+
+	private static readonly object InterestLock = new();
+	private static readonly Dictionary<(NetMessageDirection Direction, int MsgId), int> SerializedInterestCounts = new();
+	private static readonly Dictionary<(NetMessageDirection Direction, int MsgId), int> FastInterestCounts = new();
+	private static readonly Dictionary<int, int> UserMessageSerializedInterestCounts = new();
+	private static readonly Dictionary<int, int> UserMessageFastInterestCounts = new();
 
 	/// <summary>
 	/// Sends a protobuf net message to the specified recipients.
@@ -34,7 +40,7 @@ public static class NetMessages
 	/// </summary>
 	/// <typeparam name="T">The protobuf message type to intercept.</typeparam>
 	/// <param name="handler">Called with the message context; return <see cref="HookResult.Handled"/> to suppress the message.</param>
-	/// <returns>A handle that keeps the hook alive. Dispose or call <see cref="UnhookOutgoing{T}"/> to remove it.</returns>
+	/// <returns>A handle that keeps the hook alive. Call <see cref="IHandle.Cancel"/> or <see cref="UnhookOutgoing{T}"/> to remove it.</returns>
 	/// <exception cref="InvalidOperationException">Thrown if <typeparamref name="T"/> has no registered message ID.</exception>
 	public static IHandle HookOutgoing<T>(Func<OutgoingMessageContext<T>, HookResult> handler)
 		where T : IMessage<T>, new()
@@ -51,7 +57,7 @@ public static class NetMessages
 	/// </summary>
 	/// <typeparam name="T">The protobuf message type to intercept.</typeparam>
 	/// <param name="handler">Called with the message context; return <see cref="HookResult.Handled"/> to suppress processing.</param>
-	/// <returns>A handle that keeps the hook alive. Dispose or call <see cref="UnhookIncoming{T}"/> to remove it.</returns>
+	/// <returns>A handle that keeps the hook alive. Call <see cref="IHandle.Cancel"/> or <see cref="UnhookIncoming{T}"/> to remove it.</returns>
 	/// <exception cref="InvalidOperationException">Thrown if <typeparamref name="T"/> has no registered message ID.</exception>
 	public static IHandle HookIncoming<T>(Func<IncomingMessageContext<T>, HookResult> handler)
 		where T : IMessage<T>, new()
@@ -83,5 +89,193 @@ public static class NetMessages
 		int msgId = NetMessageRegistry.GetMessageId<T>();
 		if (msgId >= 0)
 			OnHookRemove?.Invoke(msgId, NetMessageDirection.Incoming, handler);
+	}
+
+	/// <summary>Mounts the read-only native visitor for an incoming message id.</summary>
+	public static IHandle VisitIncoming(int msgId) => AddFastInterest(NetMessageDirection.Incoming, msgId);
+
+	/// <summary>Mounts the read-only native visitor for an outgoing message id.</summary>
+	public static IHandle VisitOutgoing(int msgId) => AddFastInterest(NetMessageDirection.Outgoing, msgId);
+
+	/// <summary>Mounts the read-only native visitor for an incoming message type.</summary>
+	public static IHandle VisitIncoming<T>() where T : IMessage<T>, new()
+	{
+		int msgId = NetMessageRegistry.GetMessageId<T>();
+		if (msgId < 0)
+			throw new InvalidOperationException($"No message ID registered for {typeof(T).Name}");
+		return VisitIncoming(msgId);
+	}
+
+	/// <summary>Mounts the read-only native visitor for an outgoing message type.</summary>
+	public static IHandle VisitOutgoing<T>() where T : IMessage<T>, new()
+	{
+		int msgId = NetMessageRegistry.GetMessageId<T>();
+		if (msgId < 0)
+			throw new InvalidOperationException($"No message ID registered for {typeof(T).Name}");
+		return VisitOutgoing(msgId);
+	}
+
+	/// <summary>
+	/// Mounts the read-only native visitor for an outgoing <c>svc_UserMessage</c> inner message type.
+	/// The full user-message payload is not parsed; <see cref="FastNetMessageEvent.UserMessageType"/> identifies matches.
+	/// </summary>
+	public static IHandle VisitUserMessage(int userMessageType) => AddUserMessageFastInterest(userMessageType);
+
+	/// <summary>Mounts the read-only native visitor for an outgoing <c>svc_UserMessage</c> inner protobuf type.</summary>
+	public static IHandle VisitUserMessage<T>() where T : IMessage<T>, new()
+	{
+		int userMessageType = NetMessageRegistry.GetMessageId<T>();
+		if (userMessageType < 0)
+			throw new InvalidOperationException($"No message ID registered for {typeof(T).Name}");
+		return VisitUserMessage(userMessageType);
+	}
+
+	internal static void AddSerializedInterest(NetMessageDirection direction, int msgId)
+	{
+		if (NativeInterop.SetNetMessageSerializedInterest == null)
+			return;
+
+		var key = (direction, msgId);
+		lock (InterestLock)
+		{
+			SerializedInterestCounts.TryGetValue(key, out int count);
+			SerializedInterestCounts[key] = count + 1;
+			if (count == 0)
+				NativeInterop.SetNetMessageSerializedInterest((int)direction, msgId, 1);
+
+			if (direction == NetMessageDirection.Outgoing && NetMessageRegistry.IsUserMessageId(msgId))
+				AddUserMessageSerializedInterestLocked(msgId);
+		}
+	}
+
+	internal static void RemoveSerializedInterest(NetMessageDirection direction, int msgId)
+	{
+		if (NativeInterop.SetNetMessageSerializedInterest == null)
+			return;
+
+		var key = (direction, msgId);
+		lock (InterestLock)
+		{
+			if (!SerializedInterestCounts.TryGetValue(key, out int count))
+				return;
+			if (count <= 1)
+			{
+				SerializedInterestCounts.Remove(key);
+				NativeInterop.SetNetMessageSerializedInterest((int)direction, msgId, 0);
+			}
+			else
+			{
+				SerializedInterestCounts[key] = count - 1;
+			}
+
+			if (direction == NetMessageDirection.Outgoing && NetMessageRegistry.IsUserMessageId(msgId))
+				RemoveUserMessageSerializedInterestLocked(msgId);
+		}
+	}
+
+	private static IHandle AddFastInterest(NetMessageDirection direction, int msgId)
+	{
+		if (NativeInterop.SetNetMessageFastInterest == null)
+			throw new NotSupportedException("Native net message visitors are not available in this Deadworks build.");
+
+		var key = (direction, msgId);
+		lock (InterestLock)
+		{
+			FastInterestCounts.TryGetValue(key, out int count);
+			FastInterestCounts[key] = count + 1;
+			if (count == 0)
+				NativeInterop.SetNetMessageFastInterest((int)direction, msgId, 1);
+		}
+
+		return new CallbackHandle(() => RemoveFastInterest(direction, msgId));
+	}
+
+	private static void RemoveFastInterest(NetMessageDirection direction, int msgId)
+	{
+		if (NativeInterop.SetNetMessageFastInterest == null)
+			return;
+
+		var key = (direction, msgId);
+		lock (InterestLock)
+		{
+			if (!FastInterestCounts.TryGetValue(key, out int count))
+				return;
+			if (count <= 1)
+			{
+				FastInterestCounts.Remove(key);
+				NativeInterop.SetNetMessageFastInterest((int)direction, msgId, 0);
+			}
+			else
+			{
+				FastInterestCounts[key] = count - 1;
+			}
+		}
+	}
+
+	private static void AddUserMessageSerializedInterestLocked(int userMessageType)
+	{
+		if (NativeInterop.SetUserMessageSerializedInterest == null)
+			return;
+
+		UserMessageSerializedInterestCounts.TryGetValue(userMessageType, out int count);
+		UserMessageSerializedInterestCounts[userMessageType] = count + 1;
+		if (count == 0)
+			NativeInterop.SetUserMessageSerializedInterest(userMessageType, 1);
+	}
+
+	private static void RemoveUserMessageSerializedInterestLocked(int userMessageType)
+	{
+		if (NativeInterop.SetUserMessageSerializedInterest == null)
+			return;
+
+		if (!UserMessageSerializedInterestCounts.TryGetValue(userMessageType, out int count))
+			return;
+		if (count <= 1)
+		{
+			UserMessageSerializedInterestCounts.Remove(userMessageType);
+			NativeInterop.SetUserMessageSerializedInterest(userMessageType, 0);
+		}
+		else
+		{
+			UserMessageSerializedInterestCounts[userMessageType] = count - 1;
+		}
+	}
+
+	private static IHandle AddUserMessageFastInterest(int userMessageType)
+	{
+		ArgumentOutOfRangeException.ThrowIfNegative(userMessageType);
+		if (NativeInterop.SetUserMessageFastInterest == null)
+			throw new NotSupportedException("Native user-message visitors are not available in this Deadworks build.");
+
+		lock (InterestLock)
+		{
+			UserMessageFastInterestCounts.TryGetValue(userMessageType, out int count);
+			UserMessageFastInterestCounts[userMessageType] = count + 1;
+			if (count == 0)
+				NativeInterop.SetUserMessageFastInterest(userMessageType, 1);
+		}
+
+		return new CallbackHandle(() => RemoveUserMessageFastInterest(userMessageType));
+	}
+
+	private static void RemoveUserMessageFastInterest(int userMessageType)
+	{
+		if (NativeInterop.SetUserMessageFastInterest == null)
+			return;
+
+		lock (InterestLock)
+		{
+			if (!UserMessageFastInterestCounts.TryGetValue(userMessageType, out int count))
+				return;
+			if (count <= 1)
+			{
+				UserMessageFastInterestCounts.Remove(userMessageType);
+				NativeInterop.SetUserMessageFastInterest(userMessageType, 0);
+			}
+			else
+			{
+				UserMessageFastInterestCounts[userMessageType] = count - 1;
+			}
+		}
 	}
 }

--- a/managed/EntryPoint.cs
+++ b/managed/EntryPoint.cs
@@ -120,15 +120,20 @@ public static class EntryPoint
 
         *outRecipientMask = modifiedRecipientMask;
 
-        if (modifiedBytes != null)
+        if (modifiedBytes != null && modifiedBytes.Length <= 65536)
         {
-            var outSpan = new Span<byte>(outBytes, 65536);
-            modifiedBytes.AsSpan().CopyTo(outSpan);
+            if (modifiedBytes.Length > 0)
+            {
+                var outSpan = new Span<byte>(outBytes, 65536);
+                modifiedBytes.AsSpan().CopyTo(outSpan);
+            }
             *outLen = modifiedBytes.Length;
         }
         else
         {
-            *outLen = 0;
+            if (modifiedBytes != null)
+                Console.WriteLine($"[PluginLoader] Modified net message {msgId} exceeded 64KiB; leaving original payload unchanged");
+            *outLen = -1;
         }
 
         return (int)result;
@@ -366,9 +371,6 @@ public static class EntryPoint
         int offset = 0;
         var span = new ReadOnlySpan<byte>(batchBytes, batchLen);
 
-        // Snapshot original bytes for modification detection
-        var originalBytes = span.ToArray();
-
         for (int i = 0; i < numCmds && offset + 4 <= batchLen; i++)
         {
             int len = BitConverter.ToInt32(span.Slice(offset, 4));
@@ -416,7 +418,7 @@ public static class EntryPoint
         }
 
         // Only signal modification if the serialized output differs from the original
-        if (writeOffset > 0 && !outSpan.Slice(0, writeOffset).SequenceEqual(originalBytes.AsSpan()))
+        if (writeOffset > 0 && !outSpan.Slice(0, writeOffset).SequenceEqual(span))
         {
             *outBatchLen = writeOffset;
         }
@@ -459,6 +461,30 @@ public static class EntryPoint
         };
 
         PluginLoader.DispatchUsercmdTrigger(args);
+    }
+
+    [UnmanagedCallersOnly]
+    public static void OnFastNetMessage(int direction, int endpointSlot, int msgId, ulong recipientMask,
+        int userMessageType, byte hasUserMessageType,
+        int pauseType, int pauseGroup, byte hasPauseRequest,
+        byte paused, byte hasPauseState)
+    {
+        var args = new FastNetMessageEvent
+        {
+            Direction = direction == 0 ? NetMessageDirection.Incoming : NetMessageDirection.Outgoing,
+            EndpointSlot = endpointSlot,
+            MessageId = msgId,
+            RecipientMask = recipientMask,
+            UserMessageType = userMessageType,
+            HasUserMessageType = hasUserMessageType != 0,
+            PauseType = pauseType,
+            PauseGroup = pauseGroup,
+            HasPauseRequest = hasPauseRequest != 0,
+            Paused = paused != 0,
+            HasPauseState = hasPauseState != 0,
+        };
+
+        PluginLoader.DispatchFastNetMessage(args);
     }
 
     [UnmanagedCallersOnly]

--- a/managed/EntryPoint.cs
+++ b/managed/EntryPoint.cs
@@ -354,6 +354,11 @@ public static class EntryPoint
     {
         *outBatchLen = 0;
 
+        // Safety valve for mixed deployments. Native code checks this before
+        // serialization; this keeps older binaries from parsing in managed code.
+        if (Environment.GetEnvironmentVariable("DEADWORKS_DISABLE_USERCMDS") == "1")
+            return;
+
         if (batchLen <= 0 || numCmds <= 0)
             return;
 
@@ -415,6 +420,45 @@ public static class EntryPoint
         {
             *outBatchLen = writeOffset;
         }
+    }
+
+    [UnmanagedCallersOnly]
+    public static unsafe void OnFastProcessUsercmds(int playerSlot, FastUsercmd* cmds, int numCmds, byte paused, float margin)
+    {
+        if (cmds == null || numCmds <= 0)
+            return;
+
+        var managedCmds = new FastUsercmd[numCmds];
+        new ReadOnlySpan<FastUsercmd>(cmds, numCmds).CopyTo(managedCmds);
+
+        var args = new FastProcessUsercmdsEvent
+        {
+            PlayerSlot = playerSlot,
+            Usercmds = managedCmds,
+            Paused = paused != 0,
+            Margin = margin
+        };
+
+        PluginLoader.DispatchFastProcessUsercmds(args);
+    }
+
+    [UnmanagedCallersOnly]
+    public static unsafe void OnUsercmdTrigger(int playerSlot, FastUsercmd* cmd, ulong pressedButtons, ulong triggerButtons, byte paused, float margin)
+    {
+        if (cmd == null)
+            return;
+
+        var args = new UsercmdTriggerEvent
+        {
+            PlayerSlot = playerSlot,
+            Usercmd = *cmd,
+            PressedButtons = (InputButton)pressedButtons,
+            TriggerButtons = (InputButton)triggerButtons,
+            Paused = paused != 0,
+            Margin = margin
+        };
+
+        PluginLoader.DispatchUsercmdTrigger(args);
     }
 
     [UnmanagedCallersOnly]

--- a/managed/HandlerRegistry.cs
+++ b/managed/HandlerRegistry.cs
@@ -75,6 +75,8 @@ internal sealed class HandlerRegistry<TKey, THandler> where TKey : notnull
         return _handlers.TryGetValue(key, out var list) ? [.. list] : null;
     }
 
+    public bool HasAny => _handlers.Count > 0;
+
     public void Clear()
     {
         _handlers.Clear();

--- a/managed/PluginLoader.NetMessages.cs
+++ b/managed/PluginLoader.NetMessages.cs
@@ -27,6 +27,7 @@ internal static partial class PluginLoader
                 dict[msgId] = list;
             }
             list.Add(handler);
+            NetMessages.AddSerializedInterest(direction, msgId);
         }
 
         return new CallbackHandle(() =>
@@ -36,9 +37,11 @@ internal static partial class PluginLoader
                 var dict = direction == NetMessageDirection.Outgoing ? _outgoingNetMsgHandlers : _incomingNetMsgHandlers;
                 if (dict.TryGetValue(msgId, out var list))
                 {
-                    list.Remove(handler);
+                    bool removed = list.Remove(handler);
                     if (list.Count == 0)
                         dict.Remove(msgId);
+                    if (removed)
+                        NetMessages.RemoveSerializedInterest(direction, msgId);
                 }
             }
         });
@@ -51,9 +54,11 @@ internal static partial class PluginLoader
             var dict = direction == NetMessageDirection.Outgoing ? _outgoingNetMsgHandlers : _incomingNetMsgHandlers;
             if (dict.TryGetValue(msgId, out var list))
             {
-                list.Remove(handler);
+                bool removed = list.Remove(handler);
                 if (list.Count == 0)
                     dict.Remove(msgId);
+                if (removed)
+                    NetMessages.RemoveSerializedInterest(direction, msgId);
             }
         }
     }
@@ -112,6 +117,7 @@ internal static partial class PluginLoader
                     dict[msgId] = list;
                 }
                 list.Add(del);
+                NetMessages.AddSerializedInterest(direction, msgId);
                 Console.WriteLine($"[PluginLoader] Registered net message handler: {plugin.Name}.{method.Name} -> {protoType.Name} msgId={msgId} ({direction})");
             }
         }
@@ -129,9 +135,11 @@ internal static partial class PluginLoader
             var dict = dir == NetMessageDirection.Outgoing ? _outgoingNetMsgHandlers : _incomingNetMsgHandlers;
             if (dict.TryGetValue(msgId, out var list))
             {
-                list.Remove(handler);
+                bool removed = list.Remove(handler);
                 if (list.Count == 0)
                     dict.Remove(msgId);
+                if (removed)
+                    NetMessages.RemoveSerializedInterest(dir, msgId);
             }
         }
     }
@@ -163,9 +171,6 @@ internal static partial class PluginLoader
             return HookResult.Continue;
         }
 
-        // Snapshot original bytes for comparison after handlers run
-        var originalBytes = protoBytes.ToArray();
-
         var result = HookResult.Continue;
         var currentRecipientMask = recipientMask;
         foreach (var handler in handlers)
@@ -185,7 +190,7 @@ internal static partial class PluginLoader
 
         // Re-serialize if any handler may have modified the message
         var newBytes = message.ToByteArray();
-        if (!newBytes.AsSpan().SequenceEqual(originalBytes))
+        if (!newBytes.AsSpan().SequenceEqual(protoBytes))
             modifiedBytes = newBytes;
 
         return result;

--- a/managed/PluginLoader.cs
+++ b/managed/PluginLoader.cs
@@ -54,6 +54,8 @@ internal static partial class PluginLoader
     private static readonly Dictionary<int, List<Delegate>> _incomingNetMsgHandlers = new();
     private static readonly Dictionary<string, List<(int msgId, NetMessageDirection dir, Delegate handler)>> _pluginNetMsgHandlers = new(StringComparer.OrdinalIgnoreCase);
 
+    private const int CitadelChatMessageId = (int)ECitadelClientMessages.CitadelCmChatMsg;
+
     private static string _pluginsDir = "";
     public static string PluginsDir => _pluginsDir;
 
@@ -61,6 +63,7 @@ internal static partial class PluginLoader
     private static Timer? _debounceTimer;
     private static readonly HashSet<string> _pendingReloads = new(StringComparer.OrdinalIgnoreCase);
     private static UsercmdMount? _startupUsercmdMountMask;
+    private static bool _chatNetMessageInterestMounted;
 
     // Assemblies that plugins may reference from the host. Resolved once at startup
     // so every PluginLoadContext returns the same instance (preserving type identity).
@@ -249,6 +252,7 @@ internal static partial class PluginLoader
             RegisterPluginChatCommands(normalizedPath, plugins);
             ConCommandManager.RegisterPlugin(normalizedPath, plugins);
             Commands.CommandRegistration.RegisterPluginCommands(normalizedPath, plugins, _chatCommandRegistry);
+            ReconcileChatNetMessageInterest();
         }
     }
 
@@ -266,6 +270,7 @@ internal static partial class PluginLoader
             _chatCommandRegistry.UnregisterPlugin(normalizedPath);
             ConCommandManager.UnregisterPlugin(normalizedPath);
             PluginRegistrationTracker.Remove(normalizedPath);
+            ReconcileChatNetMessageInterest();
         }
 
         foreach (var plugin in entry.Plugins)
@@ -352,6 +357,30 @@ internal static partial class PluginLoader
     {
         _pluginSnapshot = _loaded.Values.SelectMany(e => e.Plugins).ToArray();
         ReconcileUsercmdMounts();
+    }
+
+    private static void ReconcileChatNetMessageInterest()
+    {
+        bool wantsChat = _chatCommandRegistry.HasAny;
+        foreach (var plugin in _pluginSnapshot)
+        {
+            if (OverridesPluginMethod(plugin.GetType(), nameof(IDeadworksPlugin.OnChatMessage), typeof(ChatMessage)))
+            {
+                wantsChat = true;
+                break;
+            }
+        }
+
+        if (wantsChat && !_chatNetMessageInterestMounted)
+        {
+            NetMessages.AddSerializedInterest(NetMessageDirection.Incoming, CitadelChatMessageId);
+            _chatNetMessageInterestMounted = true;
+        }
+        else if (!wantsChat && _chatNetMessageInterestMounted)
+        {
+            NetMessages.RemoveSerializedInterest(NetMessageDirection.Incoming, CitadelChatMessageId);
+            _chatNetMessageInterestMounted = false;
+        }
     }
 
     private static void ReconcileUsercmdMounts()
@@ -517,6 +546,9 @@ internal static partial class PluginLoader
 
     public static void DispatchUsercmdTrigger(UsercmdTriggerEvent args)
         => DispatchToPlugins(p => p.OnUsercmdTrigger(args), nameof(IDeadworksPlugin.OnUsercmdTrigger));
+
+    public static void DispatchFastNetMessage(FastNetMessageEvent args)
+        => DispatchToPlugins(p => p.OnFastNetMessage(args), nameof(IDeadworksPlugin.OnFastNetMessage));
 
     public static HookResult DispatchAddModifier(AddModifierEvent args)
         => DispatchToPluginsWithResult(p => p.OnAddModifier(args), nameof(IDeadworksPlugin.OnAddModifier));

--- a/managed/PluginLoader.cs
+++ b/managed/PluginLoader.cs
@@ -60,6 +60,7 @@ internal static partial class PluginLoader
     private static FileSystemWatcher? _watcher;
     private static Timer? _debounceTimer;
     private static readonly HashSet<string> _pendingReloads = new(StringComparer.OrdinalIgnoreCase);
+    private static UsercmdMount? _startupUsercmdMountMask;
 
     // Assemblies that plugins may reference from the host. Resolved once at startup
     // so every PluginLoadContext returns the same instance (preserving type identity).
@@ -350,6 +351,44 @@ internal static partial class PluginLoader
     private static void RebuildSnapshot()
     {
         _pluginSnapshot = _loaded.Values.SelectMany(e => e.Plugins).ToArray();
+        ReconcileUsercmdMounts();
+    }
+
+    private static void ReconcileUsercmdMounts()
+    {
+        UsercmdMount mount = UsercmdMount.None;
+        foreach (var plugin in _pluginSnapshot)
+        {
+            var type = plugin.GetType();
+            if (OverridesPluginMethod(type, nameof(IDeadworksPlugin.OnProcessUsercmds), typeof(ProcessUsercmdsEvent)))
+                mount |= UsercmdMount.FullProtobuf;
+            if (OverridesPluginMethod(type, nameof(IDeadworksPlugin.OnFastProcessUsercmds), typeof(FastProcessUsercmdsEvent)))
+                mount |= UsercmdMount.FastRead;
+            if (OverridesPluginMethod(type, nameof(IDeadworksPlugin.OnUsercmdTrigger), typeof(UsercmdTriggerEvent)))
+                mount |= UsercmdMount.ButtonTriggers;
+        }
+
+        try
+        {
+            _startupUsercmdMountMask ??= Usercmds.GetMountMask();
+            Usercmds.SetMountMask(mount | _startupUsercmdMountMask.Value);
+            if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("DEADWORKS_USERCMD_NATIVE_MODE")))
+                Usercmds.SetNativeMode(UsercmdNativeMode.MountedPolicy);
+            if (mount != UsercmdMount.None)
+                Console.WriteLine($"[PluginLoader] Mounted native usercmd features: {mount}");
+        }
+        catch (NotSupportedException)
+        {
+            // Older native Deadworks build; leave legacy behavior in place.
+        }
+    }
+
+    private static bool OverridesPluginMethod(Type type, string methodName, params Type[] argTypes)
+    {
+        var method = type.GetMethod(methodName, BindingFlags.Instance | BindingFlags.Public, binder: null, types: argTypes, modifiers: null);
+        if (method == null)
+            return false;
+        return method.DeclaringType != typeof(DeadworksPluginBase) && method.DeclaringType != typeof(IDeadworksPlugin);
     }
 
     // --- Dispatch helpers ---
@@ -472,6 +511,12 @@ internal static partial class PluginLoader
 
     public static void DispatchProcessUsercmds(ProcessUsercmdsEvent args)
         => DispatchToPlugins(p => p.OnProcessUsercmds(args), nameof(IDeadworksPlugin.OnProcessUsercmds));
+
+    public static void DispatchFastProcessUsercmds(FastProcessUsercmdsEvent args)
+        => DispatchToPlugins(p => p.OnFastProcessUsercmds(args), nameof(IDeadworksPlugin.OnFastProcessUsercmds));
+
+    public static void DispatchUsercmdTrigger(UsercmdTriggerEvent args)
+        => DispatchToPlugins(p => p.OnUsercmdTrigger(args), nameof(IDeadworksPlugin.OnUsercmdTrigger));
 
     public static HookResult DispatchAddModifier(AddModifierEvent args)
         => DispatchToPluginsWithResult(p => p.OnAddModifier(args), nameof(IDeadworksPlugin.OnAddModifier));


### PR DESCRIPTION
## Summary
- add native mounted net-message visitor runtime with serialized/fast interest gates for incoming, outgoing, and nested `svc_UserMessage` ids
- add managed `FastNetMessageEvent`, `OnFastNetMessage`, and `NetMessages.Visit*` APIs while keeping existing full protobuf hook/send APIs for mutation and blocking
- add docs/config plus a DiagnosticsPlugin for local visitor and command smoke testing

Stacked on #27 (`feat/deadworks-usercmd-visitors-pr`). Until #27 is merged, this PR includes that base commit in the comparison.

## Hot-path notes
- no serialized/fast net interest: hooks return without protobuf serialization or managed dispatch; diagnostics counters are gated behind `DEADWORKS_NETMSG_PROBE_LOG`
- full protobuf parsing/serialization remains only on mounted compatibility hooks
- nested user-message handlers first gate on `svc_UserMessage.msg_type` before parsing payloads
- DiagnosticsPlugin throttles high-frequency touch logs to 5s summaries by default

## Validation
- `dotnet build managed/DeadworksManaged.csproj -c Release --no-restore`
- `DOTNET_ROLL_FORWARD=Major dotnet test managed/DeadworksManaged.Tests/DeadworksManaged.Tests.csproj -c Release --no-restore` (25 passed)
- `dotnet build examples/ExamplePlugins.slnx -c Release --no-restore`
- VS18 MSBuild Release native build of `deadworks/deadworks.vcxproj`
- `git diff --cached --check`
- grep audit saved at `/tmp/deadworks-pr-cached-audit.txt`
- live E2E logs captured locally for diagnostics/no-interest baseline/mutation paths:
  - `/tmp/deadworks-net-e2e-summary-with-diagnostics.txt`
  - `/tmp/deadworks-net-e2e-baseline-summary.txt`
  - `/tmp/deadworks-net-e2e-mutation-summary.txt`
