### PR TITLE
fix: defer plugin precache until managed runtime is ready

### DIFF
--- a/deadworks/src/Core/Deadworks.cpp
+++ b/deadworks/src/Core/Deadworks.cpp
@@ -257,13 +257,23 @@ void Deadworks::PostInit() {
 
     // Resolve statics needed by Native* callbacks
     ResolveNativeStatics();
+    // Proton: manifest hook can fire before ApplyGameSettings; init .NET here so precache runs inline.
+    EnsureManagedInitialized();
+}
+
+// Idempotent — safe from PostInit and ApplyGameSettings.
+void Deadworks::EnsureManagedInitialized() {
+    if (m_dotnetInitialized)
+        return;
+
+    m_dotnetInitialized = true;
+    InitializeManagedCallbacks(m_dotnetHost, m_managed);
 }
 
 void Deadworks::On_ISource2Server_ApplyGameSettings() {
-    if (!m_dotnetInitialized) {
-        m_dotnetInitialized = true;
-        InitializeManagedCallbacks(m_dotnetHost, m_managed);
-    }
+    EnsureManagedInitialized();
+    // Fallback if manifest hook ran before PostInit path (should be rare after early init).
+    FlushDeferredPluginPrecache();
 }
 
 void Deadworks::On_StartupServer(const char *pszMapName) {
@@ -437,13 +447,59 @@ void Deadworks::OnEntityDeleted(CEntityInstance *pEntity) {
         m_managed.onEntityDeleted(pEntity);
 }
 
-void Deadworks::OnBuildGameSessionManifest(void *manifest) {
-    if (!m_managed.onPrecacheResources || !manifest)
+void Deadworks::DispatchPluginPrecache(void *manifest, PluginResourceCtx *resourceCtx) {
+    // Single path for hook and deferred flush; sets g_pCurrentManifest for Precache.Add*.
+    if (!m_managed.onPrecacheResources || !manifest || !resourceCtx)
         return;
 
+    resourceCtx->manifest = manifest;
+    g_pCurrentResourceCtx = resourceCtx;
     g_pCurrentManifest = manifest;
     m_managed.onPrecacheResources();
     g_pCurrentManifest = nullptr;
+    g_pCurrentResourceCtx = nullptr;
+}
+
+void Deadworks::OnBuildGameSessionManifest(void *gameRules, void **manifestSlot, PluginResourceCtx *resourceCtx) {
+    if (!gameRules || !manifestSlot || !resourceCtx)
+        return;
+
+    if (!m_managed.onPrecacheResources) {
+        // Keep slot pointer (game rules member), not *manifest — stale copy crashes AddHero on flush.
+        m_pendingGameRules = gameRules;
+        m_pendingManifestSlot = manifestSlot;
+        g_Log->Info("Deferred plugin precache until .NET runtime is ready (rules={:p})", gameRules);
+        return;
+    }
+
+    void *manifest = *manifestSlot;
+    if (!manifest)
+        return;
+
+    DispatchPluginPrecache(manifest, resourceCtx);
+}
+
+void Deadworks::FlushDeferredPluginPrecache() {
+    if (!m_pendingManifestSlot || !m_managed.onPrecacheResources)
+        return;
+
+    void **manifestSlot = m_pendingManifestSlot;
+    m_pendingGameRules = nullptr;
+    m_pendingManifestSlot = nullptr;
+
+    if (!IsHeroPrecacheResolved())
+        ResolveHeroPrecacheFns();
+
+    void *manifest = manifestSlot ? *manifestSlot : nullptr;
+    if (!manifest) {
+        g_Log->Warning("Deferred precache skipped — manifest slot empty");
+        return;
+    }
+
+    PluginResourceCtx resourceCtx{};
+    g_Log->Info("Flushing deferred plugin precache (manifest={:p})", manifest);
+    // Do not re-call BuildGameSessionManifest — .call() skips our hook and never runs plugins.
+    DispatchPluginPrecache(manifest, &resourceCtx);
 }
 
 void Deadworks::On_ISource2Server_GameFrame(bool simulating, bool bFirstTick, bool bLastTick) {

--- a/deadworks/src/Core/Deadworks.hpp
+++ b/deadworks/src/Core/Deadworks.hpp
@@ -30,6 +30,13 @@ extern IGameEventSystem *g_pGameEventSystem;
 
 namespace deadworks {
 
+// Layout expected by CCitadelGameRules hero precache (AddResource / AddHero natives).
+struct PluginResourceCtx {
+    int64_t a = 0;
+    int64_t b = 0;
+    void *manifest = nullptr;
+};
+
 class Deadworks {
 public:
     void InitFromAppSystem(CAppSystemDict *pAppSystem);
@@ -68,8 +75,10 @@ public:
     void OnEntityDeleted(CEntityInstance *pEntity);
     // Client ConCommands
     bool OnPre_ClientConCommand(void *controller, void *args);
-    // Precache
-    void OnBuildGameSessionManifest(void *manifest);
+    // Precache — see DispatchPluginPrecache / EnsureManagedInitialized in Deadworks.cpp
+    void OnBuildGameSessionManifest(void *gameRules, void **manifestSlot, PluginResourceCtx *resourceCtx);
+    void EnsureManagedInitialized();
+    void FlushDeferredPluginPrecache();
     // Touch events
     void OnStartTouch(CBaseEntity *entity, CBaseEntity *other);
     void OnEndTouch(CBaseEntity *entity, CBaseEntity *other);
@@ -106,6 +115,7 @@ public:
     }
 
 private:
+    void DispatchPluginPrecache(void *manifest, PluginResourceCtx *resourceCtx);
     void GetInterfaceFactories();
 
     struct CInterfaceFactories {
@@ -125,6 +135,9 @@ private:
     DotNetHost m_dotnetHost;
     bool m_dotnetInitialized = false;
     ManagedCallbacks m_managed{};
+    // Set when manifest hook runs before onPrecacheResources is bound (Docker/Proton boot order).
+    void *m_pendingGameRules = nullptr;
+    void **m_pendingManifestSlot = nullptr;
 };
 
 inline Deadworks g_Deadworks;

--- a/deadworks/src/Core/Hooks/BuildGameSessionManifest.cpp
+++ b/deadworks/src/Core/Hooks/BuildGameSessionManifest.cpp
@@ -8,14 +8,10 @@ __int64 __fastcall deadworks::hooks::Hook_BuildGameSessionManifest(void *thisptr
     if (!IsHeroPrecacheResolved())
         ResolveHeroPrecacheFns();
 
-    // Build resource context for hero precaching: {int128 zero, manifest_ptr}
-    struct { __int64 a; __int64 b; void *manifest; } resourceCtx = { 0, 0, *a2 };
-    g_pCurrentResourceCtx = &resourceCtx;
-
-    // Let managed plugins precache resources (including heroes)
     void *manifest = *a2;
-    g_Deadworks.OnBuildGameSessionManifest(manifest);
-
-    g_pCurrentResourceCtx = nullptr;
+    PluginResourceCtx resourceCtx{};
+    resourceCtx.manifest = manifest;
+    // manifestSlot lets core defer or read fresh *a2 on flush without re-entering this hook.
+    g_Deadworks.OnBuildGameSessionManifest(thisptr, a2, &resourceCtx);
     return result;
 }


### PR DESCRIPTION
BuildGameSessionManifest can run before ApplyGameSettings binds the .NET host (seen under Proton/Docker boot order). Defer precache until callbacks are available, flush once initialized, and call EnsureManagedInitialized from PostInit so inline precache works when timing allows.

Fixes plugin hero/resource precache being skipped (e.g. KOTH objective assets spawning without precached models).