### PR TITLE
Add hooks to restore pregame state flow on non-matchmade servers

### DIFF
--- a/config/deadworks_mem.jsonc
+++ b/config/deadworks_mem.jsonc
@@ -100,6 +100,14 @@
 			"library": "server.dll",
 			"windows": "48 89 54 24 ?? 48 89 4C 24 ?? 55 53 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? ?? ?? ?? 4C 8B FA"
 		},
+		"CCitadelGameRules::ChangeGameState": {
+			"library": "server.dll",
+			"windows": "48 89 5C 24 18 55 56 57 41 54 41 55 41 56 41 57 48 8D 6C 24 A0 48 81 EC 60 01 00 00 4C 8D A9 FC 00 00 00"
+		},
+		"CCitadelGameRules::GetWaitingForPlayersRoster": {
+			"library": "server.dll",
+			"windows": "48 8B C4 4C 89 40 18 48 89 50 10 88 48 08 55 53 56 48 8D 68 A1 48 81 EC A0 00 00 00 48 89 78 E0 33 F6 4C 89 60 D8 33 FF 4C 89 68 D0 45 33 E4 4C 89 70 C8 44 0F B6 E9 45 33 F6 4C 89 78 C0 44 89 75 7F 48 89 75 EF"
+		},
 		"AddResource": {
 			"library": "server.dll",
 			"windows": "48 89 5C 24 ?? 57 48 83 EC ?? 48 8B FA 48 8B D9 48 85 C9 74 ?? ?? ?? ?? 74"

--- a/deadworks/deadworks.vcxproj
+++ b/deadworks/deadworks.vcxproj
@@ -214,6 +214,8 @@ if not "$(DeadlockDir)"=="" if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(
     <ClCompile Include="src\Core\NativeHero.cpp" />
     <ClCompile Include="src\Core\ManagedCallbacks.cpp" />
     <ClCompile Include="src\Core\Hooks\BuildGameSessionManifest.cpp" />
+    <ClCompile Include="src\Core\Hooks\ChangeGameState.cpp" />
+    <ClCompile Include="src\Core\Hooks\WaitingForPlayersRoster.cpp" />
     <ClCompile Include="src\Memory\MemoryDataLoader.cpp" />
     <ClCompile Include="src\Memory\Scanner.cpp" />
     <ClCompile Include="src\SDK\Interfaces.cpp" />
@@ -255,6 +257,8 @@ if not "$(DeadlockDir)"=="" if exist "$(TargetDir)$(TargetName).pdb" copy /Y "$(
     <ClInclude Include="src\Core\Hooks\CheckTransmit.hpp" />
     <ClInclude Include="src\Core\Hooks\InitializeHeroOnPawn.hpp" />
     <ClInclude Include="src\Core\Hooks\BuildGameSessionManifest.hpp" />
+    <ClInclude Include="src\Core\Hooks\ChangeGameState.hpp" />
+    <ClInclude Include="src\Core\Hooks\WaitingForPlayersRoster.hpp" />
     <ClInclude Include="src\Core\A2SPatch.hpp" />
     <ClInclude Include="src\Core\Deadworks.hpp" />
     <ClInclude Include="src\Core\NativeCallbacks.hpp" />

--- a/deadworks/src/Core/Deadworks.cpp
+++ b/deadworks/src/Core/Deadworks.cpp
@@ -13,6 +13,8 @@
 #include "Hooks/PostEventAbstract.hpp"
 #include "Hooks/CCitadelPlayerPawn.hpp"
 #include "Hooks/BuildGameSessionManifest.hpp"
+#include "Hooks/ChangeGameState.hpp"
+#include "Hooks/WaitingForPlayersRoster.hpp"
 #include "Hooks/CCitadelPlayerController.hpp"
 #include "Hooks/EntityIO.hpp"
 #include "Hooks/TraceShape.hpp"
@@ -226,6 +228,12 @@ void Deadworks::PostInit() {
     HookInline(hooks::g_BuildGameSessionManifest,
                "CCitadelGameRules::BuildGameSessionManifest",
                &hooks::Hook_BuildGameSessionManifest);
+    HookInline(hooks::g_ChangeGameState,
+               "CCitadelGameRules::ChangeGameState",
+               &hooks::Hook_ChangeGameState);
+    HookInline(hooks::g_WaitingForPlayersRoster,
+               "CCitadelGameRules::GetWaitingForPlayersRoster",
+               &hooks::Hook_WaitingForPlayersRoster);
     HookInline(hooks::g_TraceShape,
                "TraceShape",
                &hooks::Hook_TraceShape);
@@ -444,6 +452,18 @@ void Deadworks::OnBuildGameSessionManifest(void *manifest) {
     g_pCurrentManifest = manifest;
     m_managed.onPrecacheResources();
     g_pCurrentManifest = nullptr;
+}
+
+void Deadworks::OnGameStateChanged(void *gameRules, int newState) {
+    if (m_managed.onGameStateChanged)
+        m_managed.onGameStateChanged(gameRules, newState);
+}
+
+bool Deadworks::ShouldAllowGameStateChange(void *gameRules, int currentState, int newState) {
+    // Default allow if no plugin cares, matching existing behavior for anyone not using this hook.
+    if (!m_managed.shouldAllowGameStateChange)
+        return true;
+    return m_managed.shouldAllowGameStateChange(gameRules, currentState, newState) != 0;
 }
 
 void Deadworks::On_ISource2Server_GameFrame(bool simulating, bool bFirstTick, bool bLastTick) {

--- a/deadworks/src/Core/Deadworks.hpp
+++ b/deadworks/src/Core/Deadworks.hpp
@@ -70,6 +70,9 @@ public:
     bool OnPre_ClientConCommand(void *controller, void *args);
     // Precache
     void OnBuildGameSessionManifest(void *manifest);
+    // Game state
+    void OnGameStateChanged(void *gameRules, int newState);
+    bool ShouldAllowGameStateChange(void *gameRules, int currentState, int newState);
     // Touch events
     void OnStartTouch(CBaseEntity *entity, CBaseEntity *other);
     void OnEndTouch(CBaseEntity *entity, CBaseEntity *other);

--- a/deadworks/src/Core/Hooks/ChangeGameState.cpp
+++ b/deadworks/src/Core/Hooks/ChangeGameState.cpp
@@ -1,0 +1,18 @@
+#include "ChangeGameState.hpp"
+#include "../Deadworks.hpp"
+
+// CCitadelGameRules::m_eGameState offset.
+static constexpr uintptr_t kGameStateOffset = 0xfc;
+
+void __fastcall deadworks::hooks::Hook_ChangeGameState(void *thisptr, int newState) {
+    const int currentState = *reinterpret_cast<int *>(reinterpret_cast<uintptr_t>(thisptr) + kGameStateOffset);
+
+    if (!g_Deadworks.ShouldAllowGameStateChange(thisptr, currentState, newState)) {
+        g_Log->Info("[ChangeGameState] vetoed {} -> {}", currentState, newState);
+        return;
+    }
+
+    g_Log->Info("[ChangeGameState] this={:#x} newState={}", reinterpret_cast<uintptr_t>(thisptr), newState);
+    hooks::g_ChangeGameState.call<void>(thisptr, newState);
+    g_Deadworks.OnGameStateChanged(thisptr, newState);
+}

--- a/deadworks/src/Core/Hooks/ChangeGameState.hpp
+++ b/deadworks/src/Core/Hooks/ChangeGameState.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <safetyhook.hpp>
+
+namespace deadworks {
+namespace hooks {
+
+inline safetyhook::InlineHook g_ChangeGameState;
+void __fastcall Hook_ChangeGameState(void *thisptr, int newState);
+
+} // namespace hooks
+} // namespace deadworks

--- a/deadworks/src/Core/Hooks/WaitingForPlayersRoster.cpp
+++ b/deadworks/src/Core/Hooks/WaitingForPlayersRoster.cpp
@@ -1,0 +1,42 @@
+#include "WaitingForPlayersRoster.hpp"
+#include "../Deadworks.hpp"
+
+#include <interfaces/interfaces.h>
+#include <iserver.h>
+#include <serversideclient.h>
+
+static uint32_t GetConnectedPlayerCount() {
+    if (!g_pNetworkServerService)
+        return 0;
+
+    auto *server = g_pNetworkServerService->GetIGameServer();
+    if (!server)
+        return 0;
+
+    uint32_t count = 0;
+    for (int i = 0; i < 64; ++i) {
+        auto *client = server->GetClientBySlot(CPlayerSlot(i));
+        if (client && client->IsInGame())
+            count++;
+    }
+    return count;
+}
+
+bool __fastcall deadworks::hooks::Hook_WaitingForPlayersRoster(bool flag, uint32_t *outReadyCount, uint32_t *outTotalCount) {
+    const bool ready = hooks::g_WaitingForPlayersRoster.call<bool>(flag, outReadyCount, outTotalCount);
+
+    // The engine's roster is populated by matchmaking/party data, which is always empty on a
+    // direct-connect dedicated server, so both outputs come back 0 and readiness is trivially
+    // true. Substitute real connected-player counts so the dispatcher's own transition attempt
+    // reflects an actual target.
+    if (g_WaitingForPlayersRequiredCount == 0)
+        return ready;
+
+    const uint32_t connected = GetConnectedPlayerCount();
+    if (outReadyCount)
+        *outReadyCount = connected;
+    if (outTotalCount)
+        *outTotalCount = g_WaitingForPlayersRequiredCount;
+
+    return connected >= g_WaitingForPlayersRequiredCount;
+}

--- a/deadworks/src/Core/Hooks/WaitingForPlayersRoster.hpp
+++ b/deadworks/src/Core/Hooks/WaitingForPlayersRoster.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <safetyhook.hpp>
+#include <cstdint>
+
+namespace deadworks {
+namespace hooks {
+
+inline safetyhook::InlineHook g_WaitingForPlayersRoster;
+
+// 0 disables the override, restoring the engine's native (always-empty-roster) behavior.
+// Set from managed code via GameRules.SetWaitingForPlayersRequiredCount().
+inline uint32_t g_WaitingForPlayersRequiredCount = 0;
+
+// Free function, no `this`: bool(bool, uint32_t *outReadyCount, uint32_t *outTotalCount).
+// Called once per tick from CCitadelGameRules's WaitingForPlayersToJoin dispatch. The return
+// value gates whether the dispatcher attempts CCitadelGameRules::ChangeGameState this tick.
+bool __fastcall Hook_WaitingForPlayersRoster(bool flag, uint32_t *outReadyCount, uint32_t *outTotalCount);
+
+} // namespace hooks
+} // namespace deadworks

--- a/deadworks/src/Core/ManagedCallbacks.cpp
+++ b/deadworks/src/Core/ManagedCallbacks.cpp
@@ -76,4 +76,6 @@ void deadworks::InitializeManagedCallbacks(DotNetHost &host, ManagedCallbacks &m
     BindCallback(host, assemblyPath, managed.onAddModifier, L"OnAddModifier");
     BindCallback(host, assemblyPath, managed.onCheckTransmit, L"OnCheckTransmit");
     BindCallback(host, assemblyPath, managed.onPawnHeroInitialized, L"OnPawnHeroInitialized");
+    BindCallback(host, assemblyPath, managed.onGameStateChanged, L"OnGameStateChanged");
+    BindCallback(host, assemblyPath, managed.shouldAllowGameStateChange, L"ShouldAllowGameStateChange");
 }

--- a/deadworks/src/Core/ManagedCallbacks.hpp
+++ b/deadworks/src/Core/ManagedCallbacks.hpp
@@ -47,6 +47,8 @@ struct ManagedCallbacks {
     using OnAddModifierFn = int(CORECLR_DELEGATE_CALLTYPE *)(void *modifierProp, void **pCaster, uint32_t *pHAbility, int32_t *pITeam, void *vdata, void *params, void *kv);
     using OnCheckTransmitFn = void(CORECLR_DELEGATE_CALLTYPE *)(int playerSlot, void *transmitBits);
     using OnPawnHeroInitializedFn = void(CORECLR_DELEGATE_CALLTYPE *)(void *pawn);
+    using OnGameStateChangedFn = void(CORECLR_DELEGATE_CALLTYPE *)(void *gameRules, int32_t newState);
+    using ShouldAllowGameStateChangeFn = uint8_t(CORECLR_DELEGATE_CALLTYPE *)(void *gameRules, int32_t currentState, int32_t newState);
 
     OnStartupServerFn onStartupServer = nullptr;
     OnTakeDamageOldFn onTakeDamageOld = nullptr;
@@ -75,6 +77,8 @@ struct ManagedCallbacks {
     OnAddModifierFn onAddModifier = nullptr;
     OnCheckTransmitFn onCheckTransmit = nullptr;
     OnPawnHeroInitializedFn onPawnHeroInitialized = nullptr;
+    OnGameStateChangedFn onGameStateChanged = nullptr;
+    ShouldAllowGameStateChangeFn shouldAllowGameStateChange = nullptr;
 };
 
 void InitializeManagedCallbacks(DotNetHost &host, ManagedCallbacks &managed);

--- a/deadworks/src/Core/NativeCallbacks.cpp
+++ b/deadworks/src/Core/NativeCallbacks.cpp
@@ -10,6 +10,8 @@
 #include "Hooks/GameEvents.hpp"
 #include "Hooks/PostEventAbstract.hpp"
 #include "Hooks/BuildGameSessionManifest.hpp"
+#include "Hooks/ChangeGameState.hpp"
+#include "Hooks/WaitingForPlayersRoster.hpp"
 
 #include "Hooks/TraceShape.hpp"
 #include "../Memory/MemoryDataLoader.hpp"
@@ -897,6 +899,19 @@ static uint8_t __cdecl NativeAddConCommandFlags(const char *name, uint64_t flags
     return 1;
 }
 
+static void __cdecl NativeChangeGameState(void *gameRules, int32_t newState) {
+    if (!gameRules)
+        return;
+    // .call() on the InlineHook always invokes the trampoline (original, unhooked code) and
+    // never re-enters Hook_ChangeGameState, so this is safe from recursion while still running
+    // every bit of the engine's real transition logic (timer setup, per-state setup, jump table).
+    hooks::g_ChangeGameState.call<void>(gameRules, newState);
+}
+
+static void __cdecl NativeSetWaitingForPlayersRequiredCount(uint32_t count) {
+    hooks::g_WaitingForPlayersRequiredCount = count;
+}
+
 // ---------------------------------------------------------------------------
 // Entity virtual function wrappers
 // ---------------------------------------------------------------------------
@@ -1184,4 +1199,7 @@ void deadworks::PopulateNativeCallbacks(NativeCallbacks &callbacks) {
 
     // ConCommand flag mutation
     callbacks.AddConCommandFlags = &NativeAddConCommandFlags;
+
+    callbacks.ChangeGameState = &NativeChangeGameState;
+    callbacks.SetWaitingForPlayersRequiredCount = &NativeSetWaitingForPlayersRequiredCount;
 }

--- a/deadworks/src/Core/NativeCallbacks.hpp
+++ b/deadworks/src/Core/NativeCallbacks.hpp
@@ -138,6 +138,13 @@ struct NativeCallbacks {
     void(__cdecl *VariantToVector)(const void *variantPtr, float *outXYZW);  // populates 4 floats; zero-pads unused components
     uint32_t(__cdecl *VariantToColor)(const void *variantPtr);  // packed RGBA (R in low byte)
     uint8_t(__cdecl *AddConCommandFlags)(const char *name, uint64_t flags);
+    // Calls the real CCitadelGameRules::ChangeGameState(this, newState) instead of raw-writing
+    // m_eGameState, so the engine's actual transition logic (timers, per-state setup) runs and
+    // the change isn't just silently overwritten on the next legitimate transition.
+    void(__cdecl *ChangeGameState)(void *gameRules, int32_t newState);
+    // Overrides the target used by CCitadelGameRules's WaitingForPlayersToJoin roster/readiness
+    // check (see Hooks/WaitingForPlayersRoster.hpp). 0 disables the override.
+    void(__cdecl *SetWaitingForPlayersRequiredCount)(uint32_t count);
 };
 
 void PopulateNativeCallbacks(NativeCallbacks &callbacks);

--- a/managed/DeadworksManaged.Api/DeadworksPluginBase.cs
+++ b/managed/DeadworksManaged.Api/DeadworksPluginBase.cs
@@ -33,4 +33,6 @@ public abstract class DeadworksPluginBase : IDeadworksPlugin {
 	public virtual HookResult OnAddModifier(AddModifierEvent args) => HookResult.Continue;
 	public virtual void OnConfigReloaded() { }
 	public virtual void OnCheckTransmit(CheckTransmitEvent args) { }
+	public virtual void OnGameStateChanged(EGameState newState) { }
+	public virtual bool OnGameStateChanging(EGameState currentState, EGameState newState) => true;
 }

--- a/managed/DeadworksManaged.Api/GameRules.cs
+++ b/managed/DeadworksManaged.Api/GameRules.cs
@@ -58,6 +58,46 @@ public static unsafe class GameRules
 	public static ulong MatchID => _gameRulesPtr != 0 ? _matchID.Get(_gameRulesPtr) : 0;
 	public static bool ServerPaused => _gameRulesPtr != 0 && _serverPaused.Get(_gameRulesPtr) != 0;
 
+	/// <summary>Calls the real CCitadelGameRules::ChangeGameState, running the engine's normal transition logic.</summary>
+	public static void ChangeGameState(EGameState state)
+	{
+		if (_gameRulesPtr != 0)
+			NativeInterop.ChangeGameState((void*)_gameRulesPtr, (int)state);
+	}
+
+	/// <summary>
+	/// Overrides the target used by the engine's internal WaitingForPlayersToJoin roster check.
+	/// The engine's own roster is populated by matchmaking/party data, which is always empty on a
+	/// direct-connect dedicated server, so the check (and the total it caches into the
+	/// client-networked HUD field) reflects a real target instead of always reading empty/zero.
+	/// Pass 0 to disable the override and restore the engine's native behavior.
+	/// </summary>
+	public static void SetWaitingForPlayersRequiredCount(uint count) => NativeInterop.SetWaitingForPlayersRequiredCount(count);
+
+	/// <summary>
+	/// Sets m_flGameStartTime, which the match clock (<see cref="GameClock"/> and the client's HUD
+	/// timer) is computed relative to. On a server without real matchmaking, this field is never
+	/// reset once the pregame flow actually reaches GameInProgress, so the clock counts from map
+	/// load instead of from when the match really starts.
+	/// </summary>
+	public static void SetGameStartTime(float time)
+	{
+		if (_gameRulesPtr != 0)
+			_gameStartTime.Set(_gameRulesPtr, time);
+	}
+
+	/// <summary>
+	/// Sets m_flGameStateEndTime, which drives the client's countdown display for states that show
+	/// one (e.g. PreGameWait's "Game starting..."). The engine's own ChangeGameState only writes a
+	/// real value here when an internal eligibility check passes; on servers where that check never
+	/// passes, the field is left at a sentinel and the client shows no countdown number.
+	/// </summary>
+	public static void SetGameStateEndTime(float time)
+	{
+		if (_gameRulesPtr != 0)
+			_gameStateEndTime.Set(_gameRulesPtr, time);
+	}
+
 	// CGameRules
 
 	public static bool GamePaused => _gameRulesPtr != 0 && _gamePaused.Get(_gameRulesPtr) != 0;

--- a/managed/DeadworksManaged.Api/IDeadworksPlugin.cs
+++ b/managed/DeadworksManaged.Api/IDeadworksPlugin.cs
@@ -127,4 +127,14 @@ public interface IDeadworksPlugin {
 	/// Called whenever a pawn's hero abilities and modifiers have just been (re)populated server-side.
 	/// </summary>
 	void OnPawnHeroInitialized(CCitadelPlayerPawn pawn) { }
+
+	/// <summary>Called after a real engine-driven CCitadelGameRules::ChangeGameState transition completes.</summary>
+	void OnGameStateChanged(EGameState newState) { }
+
+	/// <summary>
+	/// Called before a real CCitadelGameRules::ChangeGameState transition is allowed to proceed.
+	/// Return false to veto it. If multiple plugins implement this, any plugin returning false
+	/// vetoes the transition. Default: allow.
+	/// </summary>
+	bool OnGameStateChanging(EGameState currentState, EGameState newState) => true;
 }

--- a/managed/DeadworksManaged.Api/NativeCallbacks.cs
+++ b/managed/DeadworksManaged.Api/NativeCallbacks.cs
@@ -127,4 +127,6 @@ internal struct NativeCallbacks
 	public nint VariantToVector;
 	public nint VariantToColor;
 	public nint AddConCommandFlags;
+	public nint ChangeGameState;
+	public nint SetWaitingForPlayersRequiredCount;
 }

--- a/managed/DeadworksManaged.Api/NativeInterop.cs
+++ b/managed/DeadworksManaged.Api/NativeInterop.cs
@@ -129,4 +129,6 @@ internal static unsafe class NativeInterop
 	public static delegate* unmanaged[Cdecl]<void*, float*, void> VariantToVector => (delegate* unmanaged[Cdecl]<void*, float*, void>)_cb.VariantToVector;
 	public static delegate* unmanaged[Cdecl]<void*, uint> VariantToColor => (delegate* unmanaged[Cdecl]<void*, uint>)_cb.VariantToColor;
 	public static delegate* unmanaged[Cdecl]<byte*, ulong, byte> AddConCommandFlags => (delegate* unmanaged[Cdecl]<byte*, ulong, byte>)_cb.AddConCommandFlags;
+	public static delegate* unmanaged[Cdecl]<void*, int, void> ChangeGameState => (delegate* unmanaged[Cdecl]<void*, int, void>)_cb.ChangeGameState;
+	public static delegate* unmanaged[Cdecl]<uint, void> SetWaitingForPlayersRequiredCount => (delegate* unmanaged[Cdecl]<uint, void>)_cb.SetWaitingForPlayersRequiredCount;
 }

--- a/managed/EntryPoint.cs
+++ b/managed/EntryPoint.cs
@@ -434,6 +434,19 @@ public static class EntryPoint
     }
 
     [UnmanagedCallersOnly]
+    public static unsafe void OnGameStateChanged(void* gameRules, int newState)
+    {
+        PluginLoader.DispatchGameStateChanged((EGameState)newState);
+    }
+
+    [UnmanagedCallersOnly]
+    public static unsafe byte ShouldAllowGameStateChange(void* gameRules, int currentState, int newState)
+    {
+        var allow = PluginLoader.DispatchShouldAllowGameStateChange((EGameState)currentState, (EGameState)newState);
+        return (byte)(allow ? 1 : 0);
+    }
+
+    [UnmanagedCallersOnly]
     public static unsafe int OnAddModifier(void* modifierProp, void** pCaster, uint* pHAbility, int* pITeam, void* vdata, void* modifierParams, void* kv)
     {
         if (modifierProp == null || vdata == null)

--- a/managed/PluginLoader.cs
+++ b/managed/PluginLoader.cs
@@ -482,6 +482,29 @@ internal static partial class PluginLoader
     public static void DispatchPawnHeroInitialized(CCitadelPlayerPawn pawn)
         => DispatchToPlugins(p => p.OnPawnHeroInitialized(pawn), nameof(IDeadworksPlugin.OnPawnHeroInitialized));
 
+    public static void DispatchGameStateChanged(EGameState newState)
+        => DispatchToPlugins(p => p.OnGameStateChanged(newState), nameof(IDeadworksPlugin.OnGameStateChanged));
+
+    /// <summary>Any plugin returning false vetoes the transition. Not a HookResult-style max, a plain AND.</summary>
+    public static bool DispatchShouldAllowGameStateChange(EGameState currentState, EGameState newState)
+    {
+        var snapshot = _pluginSnapshot;
+        var allow = true;
+        foreach (var plugin in snapshot)
+        {
+            try
+            {
+                if (!plugin.OnGameStateChanging(currentState, newState))
+                    allow = false;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[PluginLoader] {plugin.Name}.{nameof(IDeadworksPlugin.OnGameStateChanging)} threw: {ex.Message}");
+            }
+        }
+        return allow;
+    }
+
     public static void UnloadAll()
     {
         ServerBrowser.Shutdown();


### PR DESCRIPTION
Problem

On a dedicated server without a real matchmaking backend, CCitadelGameRules skips straight from WaitingForPlayersToJoin to GameInProgress. The readiness check the engine uses for WaitingForPlayersToJoin reads a matchmaking/party roster that's always empty on a direct-connect server, so ready >= total (0 >= 0) is trivially true the instant the server ticks. There's no way for a plugin to hold that state open or drive a real player count.

What this adds

Two native hooks and the managed API surface needed for a plugin to restore normal pacing:

- ChangeGameState hooks CCitadelGameRules::ChangeGameState directly. Plugins can veto any transition via OnGameStateChanging, and get notified after a real transition completes via OnGameStateChanged.
- WaitingForPlayersRoster hooks CCitadelGameRules::GetWaitingForPlayersRoster and lets a plugin substitute a real player-count target, so both the transition and the client-facing HUD count reflect actual connected players instead of an empty roster.

GameRules gains four setters plugins can use to drive this:
- ChangeGameState(EGameState) — calls the real transition instead of raw-writing m_eGameState
- SetWaitingForPlayersRequiredCount(uint) — the override target for the roster hook above
- SetGameStateEndTime(float) — drives per-state countdown displays (e.g. PreGameWait's "Game starting...")
- SetGameStartTime(float) — resets the match clock when GameInProgress actually begins

Scope

Framework only, no bundled plugin. This just exposes the hook points and API surface; a plugin decides how long to hold each state and what triggers the transition. We use this internally to run our own dedicated servers at Parried.GG.