### PR TITLE
fix: expose OnPawnHeroInitialized in DeadworksPluginBase

### DIFF
--- a/managed/DeadworksManaged.Api/DeadworksPluginBase.cs
+++ b/managed/DeadworksManaged.Api/DeadworksPluginBase.cs
@@ -37,4 +37,5 @@ public abstract class DeadworksPluginBase : IDeadworksPlugin {
 	public virtual HookResult OnAddModifier(AddModifierEvent args) => HookResult.Continue;
 	public virtual void OnConfigReloaded() { }
 	public virtual void OnCheckTransmit(CheckTransmitEvent args) { }
+	public virtual void OnPawnHeroInitialized(CCitadelPlayerPawn pawn) { }
 }


### PR DESCRIPTION
callbacks such as `OnPrecacheResources` are exposed in `DeadworksPluginBase`, so plugins can override them directly. but exclusively for `OnPawnHeroInitialized`, you need to explicitly reimplement `IDeadworksPlugin` to use it:
```cs
public class MyPlugin : DeadworksPluginBase, IDeadworksPlugin {
  public void OnPawnHeroInitialized(CCitadelPlayerPawn pawn) {}
}
```
this commit fixes it
